### PR TITLE
Import citation_string data from CourtListener

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ You can feed in a courtlistener Court_ID or string to find a court.
 
         from courts_db import find_court, find_court_by_id
 
-        find_court_by_id(["mass"])
+        find_court_by_id("mass")
 
         returns:
         [{

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,8 @@ You can feed in a courtlistener Court_ID or string to find a court.
             "court_url": "http://www.mass.gov/courts/sjc/",
             "type": "appellate",
             "id": "mass",
-            "location": "Massachusetts"
+            "location": "Massachusetts",
+            "citation_string": "Mass."
         }]
 
 
@@ -118,6 +119,7 @@ Fields
 9. :code:`level` ==> string; code defining where court is in system structure, ex. COLR (Court of Last Resort), IAC (Intermediate Appellate Court), GJC (General Jurisdiction Court), LJC (Limited Jurisdiction Court)
 10. :code:`location` ==> string; refers to the physical location of the main court
 11. :code:`type` ==> string; Identifies kind of cases handled (Trial, Appellate, Bankruptcy, AG)
+12. :code:`citation_string` ==> string; Identifies the string used in a citation to refer to the court
 
 Installation
 ============

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -438,7 +438,7 @@
         "type": "trial",
         "id": "ald",
         "bankruptcy": null,
-        "citation_string": ""
+        "citation_string": "D. Ala."
     },
     {
         "regex": [
@@ -2774,7 +2774,7 @@
         "type": "trial",
         "id": "fld",
         "location": "Florida",
-        "citation_string": ""
+        "citation_string": "D. Fla."
     },
     {
         "regex": [
@@ -3093,7 +3093,7 @@
         "type": "trial",
         "id": "gamd",
         "location": "Georgia",
-        "citation_string": ""
+        "citation_string": "M.D. Ga."
     },
     {
         "regex": [
@@ -3119,7 +3119,7 @@
         "type": "trial",
         "id": "gad",
         "location": "Georgia",
-        "citation_string": ""
+        "citation_string": "D. Ga."
     },
     {
         "regex": [
@@ -4451,7 +4451,7 @@
         "type": "trial",
         "id": "iad",
         "location": "Iowa",
-        "citation_string": ""
+        "citation_string": "D. Iowa"
     },
     {
         "regex": [
@@ -4568,7 +4568,7 @@
         "type": "trial",
         "id": "iad",
         "location": "Iowa",
-        "citation_string": ""
+        "citation_string": "D. Iowa"
     },
     {
         "regex": [
@@ -4691,7 +4691,7 @@
         "type": "appellate",
         "id": "ksd",
         "location": "Kansas",
-        "citation_string": ""
+        "citation_string": "D. Kan."
     },
     {
         "regex": [
@@ -4764,7 +4764,7 @@
         "type": "trial",
         "id": "kyd",
         "location": "Kentucky",
-        "citation_string": ""
+        "citation_string": "D. Ky."
     },
     {
         "regex": [
@@ -4887,7 +4887,7 @@
         "type": "trial",
         "id": "kyd",
         "location": "Kentucky",
-        "citation_string": ""
+        "citation_string": "D. Ky."
     },
     {
         "regex": [
@@ -4967,7 +4967,7 @@
         "type": "trial",
         "id": "lad",
         "location": "Louisiana",
-        "citation_string": ""
+        "citation_string": "D. La."
     },
     {
         "regex": [
@@ -5735,7 +5735,7 @@
         "type": "appellate",
         "id": "miwd",
         "location": "Michigan",
-        "citation_string": ""
+        "citation_string": "W.D. Mich."
     },
     {
         "regex": [
@@ -5781,7 +5781,7 @@
         "type": "appellate",
         "id": "michd",
         "location": "Michigan",
-        "citation_string": ""
+        "citation_string": "D. Mich."
     },
     {
         "regex": [
@@ -6064,7 +6064,7 @@
         "type": "appellate",
         "id": "missd",
         "location": "Mississippi",
-        "citation_string": ""
+        "citation_string": "D. Miss."
     },
     {
         "regex": [
@@ -6239,7 +6239,7 @@
         "type": "appellate",
         "id": "mod",
         "location": "Missouri",
-        "citation_string": ""
+        "citation_string": "D. Mo."
     },
     {
         "regex": [
@@ -7409,7 +7409,7 @@
         "type": "trial",
         "id": "nyd",
         "location": "New York",
-        "citation_string": ""
+        "citation_string": "D. N.Y."
     },
     {
         "regex": [
@@ -8304,7 +8304,7 @@
         "type": "appellate",
         "id": "nynd",
         "location": "New York",
-        "citation_string": ""
+        "citation_string": "N.D.N.Y."
     },
     {
         "regex": [
@@ -8548,7 +8548,7 @@
         "type": "trial",
         "id": "ncd",
         "location": "North Carolina",
-        "citation_string": ""
+        "citation_string": "D.N.C."
     },
     {
         "regex": [
@@ -10768,7 +10768,7 @@
         "type": "trial",
         "id": "tennworkcompapp",
         "location": "Tennessee",
-        "citation_string": ""
+        "citation_string": "Tenn. Work. Comp. App. Bd."
     },
     {
         "regex": [
@@ -11114,7 +11114,7 @@
         "type": "appellate",
         "id": "texd",
         "location": "Texas",
-        "citation_string": ""
+        "citation_string": "D. Tex."
     },
     {
         "regex": [
@@ -11574,7 +11574,7 @@
         "type": "trial",
         "id": "vad",
         "location": "Virginia",
-        "citation_string": ""
+        "citation_string": "D. Va."
     },
     {
         "regex": [
@@ -11836,7 +11836,7 @@
         "type": "trial",
         "id": "washd",
         "location": "Washington",
-        "citation_string": ""
+        "citation_string": "D. Wash."
     },
     {
         "regex": [
@@ -12126,7 +12126,7 @@
         "type": "appellate",
         "id": "wvad",
         "location": "West Virginia",
-        "citation_string": ""
+        "citation_string": "D. W.Va."
     },
     {
         "regex": [
@@ -12313,7 +12313,7 @@
         "type": "appellate",
         "id": "wied",
         "location": "Wisconsin",
-        "citation_string": "D. Wis."
+        "citation_string": "E.D. Wis."
     },
     {
         "regex": [
@@ -12334,7 +12334,7 @@
         "type": "trial",
         "id": "wisd",
         "location": "Wisconsin",
-        "citation_string": ""
+        "citation_string": "D. Wis."
     },
     {
         "regex": [
@@ -13769,7 +13769,7 @@
         "type": "appellate",
         "id": "bta",
         "location": "Washington D.C.",
-        "citation_string": ""
+        "citation_string": "B.T.A."
     },
     {
         "regex": [
@@ -13805,7 +13805,7 @@
         "type": "appellate",
         "id": "dcd",
         "location": "Washington D.C.",
-        "citation_string": "D.C."
+        "citation_string": "D.D.C."
     },
     {
         "regex": [
@@ -13826,7 +13826,7 @@
         "type": "appellate",
         "id": "orld",
         "location": "Louisiana",
-        "citation_string": ""
+        "citation_string": "D. Orleans"
     },
     {
         "regex": [
@@ -15986,7 +15986,7 @@
         "type": "appellate",
         "id": "caca",
         "examples": [],
-        "citation_string": ""
+        "citation_string": "C. Cal."
     },
     {
         "regex": [

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -28,7 +28,8 @@
             "Supreme Court of Alabama",
             "Alabama Supreme Court",
             "State Of Alabama Judicial Department Supreme Court At Law"
-        ]
+        ],
+        "citation_string": "Ala."
     },
     {
         "regex": [
@@ -51,7 +52,8 @@
         "court_url": "http://judicial.alabama.gov/civil.cfm",
         "type": "appellate",
         "id": "alacivapp",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "Ala. Civ. App."
     },
     {
         "regex": [
@@ -77,7 +79,8 @@
         "court_url": "http://judicial.alabama.gov/criminal.cfm",
         "type": "appellate",
         "id": "alacrimapp",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "Ala. Crim. App."
     },
     {
         "regex": [
@@ -102,7 +105,8 @@
         "court_url": "http://judicial.alabama.gov/",
         "type": "appellate",
         "id": "alactapp",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "Ala. Ct. App."
     },
     {
         "regex": [
@@ -127,7 +131,8 @@
         "sub_names": [
             "Numbered 1-41"
         ],
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -150,7 +155,8 @@
         "type": "trial",
         "id": "aladistct",
         "sub_names": [],
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -172,7 +178,8 @@
         "examples": [],
         "type": "trial",
         "id": "alamunict",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -193,7 +200,8 @@
         "examples": [],
         "type": "trial",
         "id": "alaproct",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -213,7 +221,8 @@
         "examples": [],
         "type": "trial",
         "id": "alajuvct",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -233,7 +242,8 @@
         "examples": [],
         "type": "trial",
         "id": "alascct",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -255,7 +265,8 @@
         "system": "state",
         "type": "trial",
         "id": "alajudct",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -299,7 +310,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "alnd",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "N.D. Ala."
     },
     {
         "regex": [
@@ -333,7 +345,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "alsd",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "S.D. Ala."
     },
     {
         "regex": [
@@ -367,7 +380,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "almd",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "M.D. Ala."
     },
     {
         "regex": [
@@ -397,7 +411,8 @@
         "level": "ljc",
         "type": "bankruptcy",
         "id": "almb",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "Bankr. M.D. Ala."
     },
     {
         "regex": [
@@ -422,7 +437,8 @@
         "active": false,
         "type": "trial",
         "id": "ald",
-        "bankruptcy": null
+        "bankruptcy": null,
+        "citation_string": ""
     },
     {
         "regex": [
@@ -445,7 +461,8 @@
         "court_url": "http://www.alnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "alnb",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "Bankr. N.D. Ala."
     },
     {
         "regex": [
@@ -467,7 +484,8 @@
         "court_url": "http://www.alsb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "alsb",
-        "location": "Alabama"
+        "location": "Alabama",
+        "citation_string": "Bankr. S.D. Ala."
     },
     {
         "regex": [
@@ -496,7 +514,8 @@
             "Third",
             "Fourth"
         ],
-        "location": "Alaska"
+        "location": "Alaska",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -525,7 +544,8 @@
             "Third",
             "Fourth"
         ],
-        "location": "Alaska"
+        "location": "Alaska",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -551,7 +571,8 @@
         "system": "state",
         "type": "appellate",
         "id": "alaskactapp",
-        "location": "Alaska"
+        "location": "Alaska",
+        "citation_string": "Alaska Ct. App."
     },
     {
         "regex": [
@@ -574,7 +595,8 @@
         "court_url": "http://courts.alaska.gov/sp.htm",
         "type": "appellate",
         "id": "alaska",
-        "location": "Alaska"
+        "location": "Alaska",
+        "citation_string": "Alaska"
     },
     {
         "regex": [
@@ -607,7 +629,8 @@
         "court_url": "http://www.akd.uscourts.gov/",
         "type": "trial",
         "id": "akd",
-        "location": "Alaska"
+        "location": "Alaska",
+        "citation_string": "D. Alaska"
     },
     {
         "regex": [
@@ -628,9 +651,10 @@
         "court_url": "http://www.akb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "akb",
-        "location": "Alaska"
+        "location": "Alaska",
+        "citation_string": "Bankr. D. Alaska"
     },
-  {
+    {
         "regex": [
             "High Court of American Samoa"
         ],
@@ -651,9 +675,10 @@
         ],
         "type": "appellate",
         "id": "amsamoa",
-        "location": "American Samoa"
+        "location": "American Samoa",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "American Samoa District Court"
         ],
@@ -674,7 +699,8 @@
         ],
         "type": "trial",
         "id": "amsamoatc",
-        "location": "American Samoa"
+        "location": "American Samoa",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -710,7 +736,8 @@
             "Yuma",
             "Prescott"
         ],
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": "D. Ariz."
     },
     {
         "regex": [
@@ -737,7 +764,8 @@
         "court_url": "http://www.azcourts.gov/azsupremecourt.aspx",
         "type": "appellate",
         "id": "ariz",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": "Ariz."
     },
     {
         "regex": [
@@ -758,14 +786,15 @@
         "system": "state",
         "locations": 2,
         "examples": [],
-        "court_url": "http://www.azcourts.gov/AZCourts/CourtofAppeals.aspx\u200e",
+        "court_url": "http://www.azcourts.gov/AZCourts/CourtofAppeals.aspx‎",
         "type": "appellate",
         "id": "arizctapp",
         "sub_names": [
             "Division One",
             "Division Two"
         ],
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": "Ariz. Ct. App."
     },
     {
         "regex": [
@@ -788,7 +817,8 @@
         "examples": [],
         "type": "trial",
         "id": "azsuperct",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -812,7 +842,8 @@
         "type": "trial",
         "id": "azjustct",
         "sub_names": [],
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -833,7 +864,8 @@
         "court_url": "http://www.superiorcourt.maricopa.gov/SuperiorCourt/TaxCourt/",
         "type": "appellate",
         "id": "ariztax",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -854,7 +886,8 @@
         "court_url": "https://ecf.azb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "arb",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": "Bankr. D. Ariz."
     },
     {
         "regex": [
@@ -887,7 +920,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "ared",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "E.D. Ark."
     },
     {
         "regex": [
@@ -924,7 +958,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "arwd",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "W.D. Ark."
     },
     {
         "regex": [
@@ -951,7 +986,8 @@
         "active": false,
         "type": "trial",
         "id": "ard",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -979,7 +1015,8 @@
         "court_url": "https://courts.arkansas.gov/courts/supreme-court",
         "type": "appellate",
         "id": "ark",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": "Ark."
     },
     {
         "regex": [
@@ -1002,7 +1039,8 @@
         "court_url": "https://courts.arkansas.gov/courts/court-of-appeals",
         "type": "appellate",
         "id": "arkctapp",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": "Ark. Ct. App."
     },
     {
         "regex": [
@@ -1024,7 +1062,8 @@
         "examples": [],
         "type": "trial",
         "id": "arkcirct",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1047,7 +1086,8 @@
         "examples": [],
         "type": "trial",
         "id": "arkdistct",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1071,7 +1111,8 @@
         "examples": [],
         "type": "trial",
         "id": "arkcityct",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1091,7 +1132,8 @@
         "court_url": "http://www.awcc.state.ar.us/",
         "type": "appellate",
         "id": "arkworkcompcom",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": "Ark. Workers' Comp."
     },
     {
         "regex": [
@@ -1111,9 +1153,10 @@
         "court_url": "http://www.arkansasag.gov/",
         "type": "ag",
         "id": "arkag",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": "Ark. Att'y Gen."
     },
-  {
+    {
         "regex": [
             "Opinion Of The Ohio Attorney General"
         ],
@@ -1130,9 +1173,10 @@
         "examples": [],
         "type": "ag",
         "id": "ohioag",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Ohio State Racing Commission"
         ],
@@ -1147,13 +1191,14 @@
         "case_types": [],
         "system": "special",
         "examples": [
-          "Ohio State Racing Commission"
+            "Ohio State Racing Commission"
         ],
         "type": "special",
         "id": "ohiorac",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Ohio Civil Rights Commission"
         ],
@@ -1168,11 +1213,12 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Ohio Civil Rights Commission"
+            "Ohio Civil Rights Commission"
         ],
         "type": "",
         "id": "ohiocivright",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1193,7 +1239,8 @@
         "court_url": "http://www.arb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "arwb",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": "Bankr. W.D. Ark."
     },
     {
         "regex": [
@@ -1214,7 +1261,8 @@
         "court_url": "http://www.arb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "areb",
-        "location": "Arkansas"
+        "location": "Arkansas",
+        "citation_string": "Bankr. E.D. Ark."
     },
     {
         "regex": [
@@ -1241,7 +1289,8 @@
         "active": false,
         "type": "trial",
         "id": "californiad",
-        "location": "California"
+        "location": "California",
+        "citation_string": "D. Cal."
     },
     {
         "regex": [
@@ -1288,7 +1337,8 @@
         "active": true,
         "type": "trial",
         "id": "casd",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "S.D. Cal."
     },
     {
         "regex": [
@@ -1334,7 +1384,8 @@
         "active": true,
         "type": "trial",
         "id": "cand",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "N.D. Cal."
     },
     {
         "regex": [
@@ -1365,7 +1416,8 @@
         "active": true,
         "type": "trial",
         "id": "caed",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "E.D. Cal."
     },
     {
         "regex": [
@@ -1410,7 +1462,8 @@
         "active": true,
         "type": "trial",
         "id": "cacd",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "C.D. Cal."
     },
     {
         "regex": [
@@ -1438,7 +1491,8 @@
         "court_url": "http://www.courts.ca.gov/supremecourt.htm",
         "type": "appellate",
         "id": "cal",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Cal."
     },
     {
         "regex": [
@@ -1471,7 +1525,8 @@
         ],
         "type": "trial",
         "id": "calsuperct",
-        "location": "California"
+        "location": "California",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1528,7 +1583,8 @@
             "Fifth",
             "Sixth"
         ],
-        "location": "California"
+        "location": "California",
+        "citation_string": "Cal. Ct. App."
     },
     {
         "regex": [
@@ -1573,7 +1629,8 @@
         ],
         "type": "appellate",
         "id": "calappdeptsuper",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Cal. App. Dep’t Super. Ct."
     },
     {
         "regex": [
@@ -1593,7 +1650,8 @@
         "court_url": "https://oag.ca.gov/",
         "type": "ag",
         "id": "calag",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Cal. Att'y Gen."
     },
     {
         "regex": [
@@ -1614,7 +1672,8 @@
         "court_url": "http://www.cacb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "cacb",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Bankr. C.D. Cal."
     },
     {
         "regex": [
@@ -1635,7 +1694,8 @@
         "court_url": "http://www.casb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "casb",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Bankr. S.D. Cal."
     },
     {
         "regex": [
@@ -1657,7 +1717,8 @@
         "court_url": "http://www.canb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "canb",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Bankr. N.D. Cal."
     },
     {
         "regex": [
@@ -1678,7 +1739,8 @@
         "court_url": "http://www.caeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "caeb",
-        "location": "California"
+        "location": "California",
+        "citation_string": "Bankr. E.D. Cal."
     },
     {
         "regex": [
@@ -1701,7 +1763,8 @@
         "examples": [],
         "type": "trial",
         "id": "colcntyct",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1723,7 +1786,8 @@
         "examples": [],
         "type": "trial",
         "id": "colmunict",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1746,7 +1810,8 @@
         "type": "trial",
         "id": "denproct",
         "sub_names": [],
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1769,7 +1834,8 @@
         "type": "trial",
         "id": "denjuvct",
         "sub_names": [],
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1795,7 +1861,8 @@
         "sub_names": [
             "First thru Twenty-Second District"
         ],
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1820,7 +1887,8 @@
         "sub_names": [
             "Water Division One thru Water Division Seven"
         ],
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -1852,7 +1920,8 @@
         "court_url": "http://www.courts.state.co.us/Courts/Court_Of_Appeals/",
         "type": "appellate",
         "id": "coloctapp",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "Colo. Ct. App."
     },
     {
         "regex": [
@@ -1875,7 +1944,8 @@
         "court_url": "http://www.coloradosupremecourt.com/",
         "type": "appellate",
         "id": "colo",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "Colo."
     },
     {
         "regex": [
@@ -1904,7 +1974,8 @@
         "court_url": "http://www.cod.uscourts.gov/",
         "type": "trial",
         "id": "cod",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "D. Colo."
     },
     {
         "regex": [
@@ -1924,7 +1995,8 @@
         "court_url": "https://www.colorado.gov/pacific/cdle/icao-wc",
         "type": "appellate",
         "id": "coloworkcompcom",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "Colo. Indus. Cl. App."
     },
     {
         "regex": [
@@ -1944,7 +2016,8 @@
         "court_url": "http://coag.gov/",
         "type": "ag",
         "id": "coloag",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "Colo. Att'y Gen."
     },
     {
         "regex": [
@@ -1966,7 +2039,8 @@
         "court_url": "http://www.cob.uscourts.gov/",
         "type": "bankruptcy",
         "id": "cob",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "Bankr.D. Colo."
     },
     {
         "regex": [
@@ -1997,7 +2071,8 @@
         "system": "federal",
         "type": "trial",
         "id": "ctd",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": "D. Conn."
     },
     {
         "regex": [
@@ -2018,7 +2093,8 @@
         "examples": [],
         "type": "trial",
         "id": "connproct",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2038,7 +2114,8 @@
         "examples": [],
         "type": "trial",
         "id": "conncirct",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2064,7 +2141,8 @@
         ],
         "type": null,
         "id": "conncpct",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2086,12 +2164,13 @@
         "system": "state",
         "locations": 13,
         "examples": [
-          "Superior Court Housing Session Of Connecticut Judicial District Of Hartford New Britain At Hartford"
+            "Superior Court Housing Session Of Connecticut Judicial District Of Hartford New Britain At Hartford"
         ],
-        "court_url": "http://www.jud.ct.gov/external/super/\u200e",
+        "court_url": "http://www.jud.ct.gov/external/super/‎",
         "type": "trial",
         "id": "connsuperct",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": "Conn. Super. Ct."
     },
     {
         "regex": [
@@ -2119,7 +2198,8 @@
         "court_url": "http://www.jud.ct.gov/external/supapp/appellate.htm",
         "type": "appellate",
         "id": "connappct",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": "Conn. App. Ct."
     },
     {
         "regex": [
@@ -2150,7 +2230,8 @@
         "active": false,
         "type": "appellate",
         "id": "conn",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": "Conn."
     },
     {
         "regex": [
@@ -2170,7 +2251,8 @@
         "court_url": "http://wcc.state.ct.us/crb/menus/crb-opin.htm",
         "type": "appellate",
         "id": "connworkcompcom",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": "Conn. Comp. Rev. Bd."
     },
     {
         "regex": [
@@ -2191,7 +2273,8 @@
         "court_url": "http://www.ctb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ctb",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": "Bankr. D. Conn."
     },
     {
         "regex": [
@@ -2221,7 +2304,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "ded",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "D. Del."
     },
     {
         "regex": [
@@ -2253,7 +2337,8 @@
         "active": false,
         "type": "appellate",
         "id": "del",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Del."
     },
     {
         "regex": [
@@ -2284,7 +2369,8 @@
         "active": false,
         "type": "non-trial",
         "id": "delch",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Del. Ch."
     },
     {
         "regex": [
@@ -2319,7 +2405,8 @@
             "New Castle",
             "Sussex"
         ],
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Del. Super. Ct. "
     },
     {
         "regex": [
@@ -2342,7 +2429,8 @@
         "active": false,
         "type": "trial",
         "id": "delfamct",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Del. Fm. Ct."
     },
     {
         "regex": [
@@ -2378,7 +2466,8 @@
         "active": true,
         "type": "trial",
         "id": "delctcompl",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Del. Ct. Com. Pl."
     },
     {
         "regex": [
@@ -2405,7 +2494,8 @@
         "active": true,
         "type": "trial",
         "id": "deljustpct",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2433,7 +2523,8 @@
         ],
         "type": "trial",
         "id": "delgensess",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2457,7 +2548,8 @@
         "system": "local",
         "type": "trial",
         "id": "delaldct",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2478,7 +2570,8 @@
         "court_url": "http://courts.delaware.gov/",
         "type": "appellate",
         "id": "deljudct",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Ct. Jud. Del."
     },
     {
         "regex": [
@@ -2499,9 +2592,9 @@
         ],
         "type": null,
         "id": "delorphct",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": ""
     },
-
     {
         "regex": [
             "Family Court of Delaware",
@@ -2518,10 +2611,11 @@
         "case_types": [],
         "system": "state",
         "examples": [],
-        "court_url": "http://courts.delaware.gov/family/\u200e",
+        "court_url": "http://courts.delaware.gov/family/‎",
         "type": "appellate",
         "id": "delfamct",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Del. Fm. Ct."
     },
     {
         "regex": [
@@ -2544,7 +2638,8 @@
         "court_url": "http://www.deb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "deb",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": "Bankr. D. Del."
     },
     {
         "regex": [
@@ -2579,7 +2674,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "flnd",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "N.D. Fla."
     },
     {
         "regex": [
@@ -2609,12 +2705,13 @@
         "appeal_to": "ca11",
         "system": "federal",
         "examples": [
-          "United States District Court In And For The Southern District Of Florida Miami Division"
+            "United States District Court In And For The Southern District Of Florida Miami Division"
         ],
         "court_url": "http://www.flsd.uscourts.gov/",
         "type": "trial",
         "id": "flsd",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "S.D. Fla."
     },
     {
         "regex": [
@@ -2649,7 +2746,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "flmd",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "M.D. Fla."
     },
     {
         "regex": [
@@ -2675,7 +2773,8 @@
         ],
         "type": "trial",
         "id": "fld",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2699,7 +2798,8 @@
         "court_url": "http://www.floridasupremecourt.org/",
         "type": "appellate",
         "id": "fla",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "Fla."
     },
     {
         "regex": [
@@ -2748,7 +2848,8 @@
             "Fourth",
             "Fifth"
         ],
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "Fla. Dist. Ct. App."
     },
     {
         "regex": [
@@ -2773,7 +2874,8 @@
         "sub_names": [
             "1st thru 20th"
         ],
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2795,7 +2897,8 @@
         "examples": [],
         "type": "trial",
         "id": "flacntyct",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -2815,7 +2918,8 @@
         "court_url": "http://www.myfloridalegal.com/",
         "type": "ag",
         "id": "flaag",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "Fla. Att'y Gen."
     },
     {
         "regex": [
@@ -2850,7 +2954,8 @@
         "court_url": "http://www.flsb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "flsb",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "Bankr. S.D. Florida"
     },
     {
         "regex": [
@@ -2874,7 +2979,8 @@
         "court_url": "http://www.flmb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "flmb",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "Bankr. M.D. Fla."
     },
     {
         "regex": [
@@ -2895,7 +3001,8 @@
         "court_url": "http://www.flnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "flnb",
-        "location": "Florida"
+        "location": "Florida",
+        "citation_string": "Bankr. N.D. Fla."
     },
     {
         "regex": [
@@ -2929,7 +3036,8 @@
         "location": "Georgia",
         "type": "trial",
         "id": "gand",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "N.D. Ga."
     },
     {
         "regex": [
@@ -2960,7 +3068,8 @@
         "court_url": "http://www.gasd.uscourts.gov/",
         "type": "trial",
         "id": "gasd",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "S.D. Ga."
     },
     {
         "regex": [
@@ -2983,7 +3092,8 @@
         "court_url": "http://www.gamd.uscourts.gov/",
         "type": "trial",
         "id": "gamd",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3008,7 +3118,8 @@
         ],
         "type": "trial",
         "id": "gad",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3033,7 +3144,8 @@
         "court_url": "http://www.gasupreme.us/",
         "type": "appellate",
         "id": "ga",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "Ga."
     },
     {
         "regex": [
@@ -3058,7 +3170,8 @@
         "court_url": "http://www.gaappeals.us/",
         "type": "appellate",
         "id": "gactapp",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "Ga. Ct. App."
     },
     {
         "regex": [
@@ -3081,7 +3194,8 @@
         "examples": [],
         "type": "trial",
         "id": "gasuperct",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3103,7 +3217,8 @@
         "examples": [],
         "type": "trial",
         "id": "gaproct",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3125,7 +3240,8 @@
         "examples": [],
         "type": "trial",
         "id": "gastct",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3146,7 +3262,8 @@
         "examples": [],
         "type": "trial",
         "id": "gamagct",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3168,7 +3285,8 @@
         "examples": [],
         "type": "trial",
         "id": "gamunict",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3190,7 +3308,8 @@
         "examples": [],
         "type": "trial",
         "id": "gajuvct",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3211,7 +3330,8 @@
         "examples": [],
         "type": "trial",
         "id": "gabizct",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3232,7 +3352,8 @@
         "examples": [],
         "type": "trial",
         "id": "ncbizct",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3254,7 +3375,8 @@
         "court_url": "http://www.ganb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ganb",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "Bankr. N.D. Ga."
     },
     {
         "regex": [
@@ -3278,7 +3400,8 @@
         "court_url": "http://www.gamb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "gamb",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "Bankr. M.D. Ga."
     },
     {
         "regex": [
@@ -3299,9 +3422,10 @@
         "court_url": "http://www.gasb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "gasb",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "Bankr. S.D. Ga."
     },
-  {
+    {
         "regex": [
             "Supreme Court Of The Commonwealth Of The Northern Mariana Islands"
         ],
@@ -3321,9 +3445,10 @@
         ],
         "type": "appellate",
         "id": "nmariana",
-        "location": "Northern Mariana Islands"
+        "location": "Northern Mariana Islands",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "${sup} Guam"
         ],
@@ -3344,7 +3469,8 @@
         ],
         "type": "appellate",
         "id": "guamsup",
-        "location": "Guam"
+        "location": "Guam",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3370,7 +3496,8 @@
         "court_url": "http://www.gud.uscourts.gov/",
         "type": "appellate",
         "id": "gud",
-        "location": "Guam"
+        "location": "Guam",
+        "citation_string": "D. Guam"
     },
     {
         "regex": [
@@ -3390,7 +3517,8 @@
         "court_url": "https://en.wikipedia.org/wiki/District_Court_of_Guam",
         "type": "bankruptcy",
         "id": "gub",
-        "location": "Guam"
+        "location": "Guam",
+        "citation_string": "Bankr. D. Guam"
     },
     {
         "regex": [
@@ -3425,7 +3553,8 @@
         "location": "Hawaii",
         "type": "trial",
         "id": "hid",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "D. Haw."
     },
     {
         "regex": [
@@ -3450,7 +3579,8 @@
         "court_url": "http://www.courts.state.hi.us/",
         "type": "appellate",
         "id": "haw",
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": "Haw."
     },
     {
         "regex": [
@@ -3473,7 +3603,8 @@
         "court_url": "http://www.courts.state.hi.us/",
         "type": "appellate",
         "id": "hawapp",
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": "Haw. App."
     },
     {
         "regex": [
@@ -3501,7 +3632,8 @@
             "Hawai'i",
             "Kaua'i"
         ],
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3529,7 +3661,8 @@
             "Hawai'i",
             "Kaua'i"
         ],
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3557,7 +3690,8 @@
             "Hawai'i",
             "Kaua'i"
         ],
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3577,7 +3711,8 @@
         "examples": [],
         "type": "appellate",
         "id": "hawtax",
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3599,7 +3734,8 @@
         "court_url": "http://www.hib.uscourts.gov/",
         "type": "bankruptcy",
         "id": "hib",
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": "Bankr. D. Haw."
     },
     {
         "regex": [
@@ -3632,7 +3768,8 @@
         "level": "gjc",
         "type": "trial",
         "id": "idd",
-        "system": "federal"
+        "system": "federal",
+        "citation_string": "D. Idaho"
     },
     {
         "regex": [
@@ -3659,7 +3796,8 @@
         "court_url": "http://www.isc.idaho.gov/",
         "type": "appellate",
         "id": "idaho",
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": "Idaho"
     },
     {
         "regex": [
@@ -3685,7 +3823,8 @@
         "court_url": "http://www.isc.idaho.gov/",
         "type": "appellate",
         "id": "idahoctapp",
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": "Idaho Ct. App."
     },
     {
         "regex": [
@@ -3716,7 +3855,8 @@
             "6th",
             "7th"
         ],
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3742,7 +3882,8 @@
             "Idaho Magistrate Division One",
             "Idaho Magistrate Division Seven"
         ],
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3762,7 +3903,8 @@
         "examples": [],
         "type": "trial",
         "id": "iddrugct",
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3782,7 +3924,8 @@
         "examples": [],
         "type": "trial",
         "id": "idmhct",
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3804,7 +3947,8 @@
         "court_url": "http://www.id.uscourts.gov/",
         "type": "bankruptcy",
         "id": "idb",
-        "location": "Idaho"
+        "location": "Idaho",
+        "citation_string": "Bankr. D. Idaho"
     },
     {
         "regex": [
@@ -3826,7 +3970,8 @@
         "court_url": "http://www.state.il.us/court/",
         "type": "appellate",
         "id": "ill",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "Ill."
     },
     {
         "regex": [
@@ -3852,27 +3997,29 @@
         "court_url": "http://www.state.il.us/court/appellatecourt/",
         "type": "appellate",
         "id": "illappct",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "Ill. App. Ct."
     },
-      {
-      "regex": [
-          "Court Of Claims Of Illinois"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "Court Of Claims Of Illinois",
-      "level": "ljc",
-      "case_types": [],
-      "system": "state",
-      "examples": [],
-      "court_url": "",
-      "type": "trial",
-      "id": "ilclaimsct",
-      "location": "Illinois"
+    {
+        "regex": [
+            "Court Of Claims Of Illinois"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "Court Of Claims Of Illinois",
+        "level": "ljc",
+        "case_types": [],
+        "system": "state",
+        "examples": [],
+        "court_url": "",
+        "type": "trial",
+        "id": "ilclaimsct",
+        "location": "Illinois",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -3893,7 +4040,8 @@
         "court_url": "http://www.ilsd.uscourts.gov/",
         "type": "appellate",
         "id": "ilsd",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "S.D. Ill."
     },
     {
         "regex": [
@@ -3916,7 +4064,8 @@
         "court_url": "https://en.wikipedia.org/wiki/United_States_District_Court_for_the_Eastern_District_of_Illinois",
         "type": "appellate",
         "id": "illinoised",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "E.D. Ill."
     },
     {
         "regex": [
@@ -3937,7 +4086,8 @@
         "court_url": "http://www.ilcd.uscourts.gov/",
         "type": "appellate",
         "id": "ilcd",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "C.D. Ill."
     },
     {
         "regex": [
@@ -3958,7 +4108,8 @@
         "court_url": "http://www.uscourts.gov/",
         "type": "appellate",
         "id": "illinoisd",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "D. Ill."
     },
     {
         "regex": [
@@ -4001,7 +4152,8 @@
         "court_url": "http://www.ilnd.uscourts.gov/",
         "type": "trial",
         "id": "ilnd",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "N.D. Ill."
     },
     {
         "regex": [
@@ -4022,7 +4174,8 @@
         "court_url": "http://www.ilsb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ilsb",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "Bankr. S.D. Ill."
     },
     {
         "regex": [
@@ -4043,7 +4196,8 @@
         "court_url": "http://www.ilcb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ilcb",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "Bankr. C.D. Ill."
     },
     {
         "regex": [
@@ -4064,7 +4218,8 @@
         "court_url": "http://www.ilnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ilnb",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "Bankr. N.D. Ill."
     },
     {
         "regex": [
@@ -4085,9 +4240,10 @@
         "court_url": "http://www.in.gov/judiciary/tax/",
         "type": "appellate",
         "id": "indtax",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Maryland Tax Court"
         ],
@@ -4104,7 +4260,8 @@
         "examples": [],
         "type": "trial",
         "id": "mdtc",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4127,7 +4284,8 @@
         "court_url": "http://www.in.gov/judiciary/appeals/",
         "type": "appellate",
         "id": "indctapp",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "Ind. Ct. App."
     },
     {
         "regex": [
@@ -4149,7 +4307,8 @@
         "court_url": "http://www.in.gov/judiciary/supreme/",
         "type": "appellate",
         "id": "ind",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "Ind."
     },
     {
         "regex": [
@@ -4172,7 +4331,8 @@
         "court_url": "http://www.insd.uscourts.gov/",
         "type": "appellate",
         "id": "indianad",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "D. Ind."
     },
     {
         "regex": [
@@ -4198,7 +4358,8 @@
         "court_url": "http://www.innd.uscourts.gov/",
         "type": "appellate",
         "id": "innd",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "N.D. Ind."
     },
     {
         "regex": [
@@ -4219,7 +4380,8 @@
         "court_url": "http://www.insd.uscourts.gov/",
         "type": "trial",
         "id": "insd",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "S.D. Ind."
     },
     {
         "regex": [
@@ -4240,7 +4402,8 @@
         "court_url": "http://www.innb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "innb",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "Bankr. N.D. Ind."
     },
     {
         "regex": [
@@ -4262,7 +4425,8 @@
         "court_url": "http://www.insb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "insb",
-        "location": "Indiana"
+        "location": "Indiana",
+        "citation_string": "Bankr. S.D. Ind."
     },
     {
         "regex": [
@@ -4286,7 +4450,8 @@
         ],
         "type": "trial",
         "id": "iad",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4307,7 +4472,8 @@
         "court_url": "http://www.iowacourts.gov/supreme_court/",
         "type": "appellate",
         "id": "iowa",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": "Iowa"
     },
     {
         "regex": [
@@ -4329,7 +4495,8 @@
         "court_url": "http://www.iowacourts.gov/court_of_appeals/",
         "type": "appellate",
         "id": "iowactapp",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": "Iowa Ct. App."
     },
     {
         "regex": [
@@ -4352,7 +4519,8 @@
         "court_url": "http://www.iasd.uscourts.gov/",
         "type": "appellate",
         "id": "iasd",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": "S.D. Iowa"
     },
     {
         "regex": [
@@ -4379,7 +4547,8 @@
         "court_url": "http://www.iand.uscourts.gov/",
         "type": "appellate",
         "id": "iand",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": "N.D. Iowa"
     },
     {
         "regex": [
@@ -4398,7 +4567,8 @@
         "examples": [],
         "type": "trial",
         "id": "iad",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4419,7 +4589,8 @@
         "court_url": "http://www.iasb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "iasb",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": "Bankr. S.D. Iowa"
     },
     {
         "regex": [
@@ -4440,7 +4611,8 @@
         "court_url": "http://www.ianb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ianb",
-        "location": "Iowa"
+        "location": "Iowa",
+        "citation_string": "Bankr. D. Iowa"
     },
     {
         "regex": [
@@ -4462,7 +4634,8 @@
         "court_url": "http://www.kscourts.org/kansas-courts/court-of-appeals/",
         "type": "appellate",
         "id": "kanctapp",
-        "location": "Kansas"
+        "location": "Kansas",
+        "citation_string": "Kan. Ct. App."
     },
     {
         "regex": [
@@ -4482,7 +4655,8 @@
         "court_url": "http://www.kscourts.org/kansas-courts/supreme-court/",
         "type": "appellate",
         "id": "kan",
-        "location": "Kansas"
+        "location": "Kansas",
+        "citation_string": "Kan."
     },
     {
         "regex": [
@@ -4516,7 +4690,8 @@
         "court_url": "http://www.ksd.uscourts.gov/",
         "type": "appellate",
         "id": "ksd",
-        "location": "Kansas"
+        "location": "Kansas",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4536,7 +4711,8 @@
         "court_url": "http://ag.ks.gov/about-the-office/contact-us",
         "type": "ag",
         "id": "kanag",
-        "location": "Kansas"
+        "location": "Kansas",
+        "citation_string": "Kan. Att'y Gen."
     },
     {
         "regex": [
@@ -4557,7 +4733,8 @@
         "court_url": "http://www.ksb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ksb",
-        "location": "Kansas"
+        "location": "Kansas",
+        "citation_string": "Bankr. D. Kan."
     },
     {
         "regex": [
@@ -4586,7 +4763,8 @@
         ],
         "type": "trial",
         "id": "kyd",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4609,7 +4787,8 @@
         "court_url": "http://courts.ky.gov/courts/coa/Pages/coa.aspx",
         "type": "appellate",
         "id": "kyctapp",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": "Ky. Ct. App."
     },
     {
         "regex": [
@@ -4627,10 +4806,11 @@
         "case_types": [],
         "system": "state",
         "examples": [],
-        "court_url": "http://courts.ky.gov/courts/supreme/\u200e",
+        "court_url": "http://courts.ky.gov/courts/supreme/‎",
         "type": "appellate",
         "id": "ky",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": "Ky."
     },
     {
         "regex": [
@@ -4656,7 +4836,8 @@
         "court_url": "http://www.kywd.uscourts.gov/",
         "type": "appellate",
         "id": "kywd",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": "W.D. Ky."
     },
     {
         "regex": [
@@ -4676,12 +4857,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "U S District Court East Dist Lexington Ky"
+            "U S District Court East Dist Lexington Ky"
         ],
         "court_url": "http://www.kyed.uscourts.gov/",
         "type": "trial",
         "id": "kyed",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": "E.D. Ky."
     },
     {
         "regex": [
@@ -4704,7 +4886,8 @@
         "examples": [],
         "type": "trial",
         "id": "kyd",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4726,7 +4909,8 @@
         "court_url": "http://www.kywb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "kywb",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": "Bankr. W.D. Ky."
     },
     {
         "regex": [
@@ -4747,7 +4931,8 @@
         "court_url": "http://www.kyeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "kyeb",
-        "location": "Kentucky"
+        "location": "Kentucky",
+        "citation_string": "Bankr. E.D. Ky."
     },
     {
         "regex": [
@@ -4781,7 +4966,8 @@
         ],
         "type": "trial",
         "id": "lad",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4807,7 +4993,8 @@
         "court_url": "http://www.lasc.org/",
         "type": "appellate",
         "id": "la",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "La."
     },
     {
         "regex": [
@@ -4841,9 +5028,10 @@
         "court_url": "http://louisiana.gov/Government/Judicial_Branch/#courtsofappeal",
         "type": "appellate",
         "id": "lactapp",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "La. Ct. App."
     },
-  {
+    {
         "regex": [
             "Superior Court Of The State Of Louisiana"
         ],
@@ -4862,7 +5050,8 @@
         ],
         "type": "trial",
         "id": "lasuperct",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -4883,7 +5072,8 @@
         "court_url": "http://www.lamd.uscourts.gov/",
         "type": "trial",
         "id": "lamd",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "M.D. La."
     },
     {
         "regex": [
@@ -4900,7 +5090,7 @@
                 "end": null
             }
         ],
-        "name":"United States District Court Eastern District Of Lousiana",
+        "name": "United States District Court Eastern District Of Lousiana",
         "level": "",
         "case_types": [],
         "system": "federal",
@@ -4910,7 +5100,8 @@
         "court_url": "http://www.laed.uscourts.gov/",
         "type": "trial",
         "id": "laed",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "E.D. La."
     },
     {
         "regex": [
@@ -4934,7 +5125,8 @@
         "court_url": "http://www.lawd.uscourts.gov/",
         "type": "trial",
         "id": "lawd",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "W.D. La."
     },
     {
         "regex": [
@@ -4954,7 +5146,8 @@
         "court_url": "https://www.ag.state.la.us/",
         "type": "ag",
         "id": "laag",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "La. Att'y Gen."
     },
     {
         "regex": [
@@ -4975,7 +5168,8 @@
         "court_url": "http://www.lamb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "lamb",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "Bankr. M.D. La."
     },
     {
         "regex": [
@@ -4997,7 +5191,8 @@
         "court_url": "http://www.laeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "laeb",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "Bankr. E.D. La."
     },
     {
         "regex": [
@@ -5018,7 +5213,8 @@
         "court_url": "http://www.lawb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "lawb",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "Bankr. W.D. La."
     },
     {
         "regex": [
@@ -5041,7 +5237,8 @@
         "court_url": "http://www.courts.state.me.us/maine_courts/supreme/",
         "type": "appellate",
         "id": "me",
-        "location": "Maine"
+        "location": "Maine",
+        "citation_string": "Me."
     },
     {
         "regex": [
@@ -5063,7 +5260,8 @@
         ],
         "type": "trial",
         "id": "mesuperct",
-        "location": "Maine"
+        "location": "Maine",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5089,7 +5287,8 @@
         "court_url": "http://www.med.uscourts.gov/",
         "type": "appellate",
         "id": "med",
-        "location": "Maine"
+        "location": "Maine",
+        "citation_string": "D. Me."
     },
     {
         "regex": [
@@ -5110,7 +5309,8 @@
         "court_url": "http://www.meb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "meb",
-        "location": "Maine"
+        "location": "Maine",
+        "citation_string": "Bankr. D. Me."
     },
     {
         "regex": [
@@ -5133,7 +5333,8 @@
         "court_url": "http://www.courts.state.md.us/cosappeals/",
         "type": "appellate",
         "id": "mdctspecapp",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": "Md. Ct. Spec. App."
     },
     {
         "regex": [
@@ -5160,7 +5361,8 @@
         "court_url": "http://www.courts.state.md.us/coappeals/",
         "type": "appellate",
         "id": "md",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": "Md."
     },
     {
         "regex": [
@@ -5186,7 +5388,8 @@
         "court_url": "https://www.mdd.uscourts.gov/",
         "type": "appellate",
         "id": "mdd",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": "D. Maryland"
     },
     {
         "regex": [
@@ -5206,7 +5409,8 @@
         "court_url": "https://www.oag.state.md.us/",
         "type": "ag",
         "id": "mdag",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": "Md. Att'y Gen."
     },
     {
         "regex": [
@@ -5233,7 +5437,8 @@
         ],
         "type": "trial",
         "id": "mdcrctct",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5255,7 +5460,8 @@
         "court_url": "http://www.mdb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "mdb",
-        "location": "Maryland"
+        "location": "Maryland",
+        "citation_string": "Bankr. D. Md."
     },
     {
         "regex": [
@@ -5281,7 +5487,8 @@
         "court_url": "http://www.mass.gov/courts/court-info/trial-court/sc/",
         "type": "appellate",
         "id": "masssuperct",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "Mass. Super. Ct."
     },
     {
         "regex": [
@@ -5311,7 +5518,8 @@
         "court_url": "http://www.mass.gov/courts/appealscourt/",
         "type": "appellate",
         "id": "massappct",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "Mass. App. Ct."
     },
     {
         "regex": [
@@ -5331,9 +5539,10 @@
         "court_url": "http://www.mass.gov/lwd/workers-compensation/",
         "type": "appellate",
         "id": "maworkcompcom",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "Mass. Dep't Indus. Accid."
     },
-      {
+    {
         "regex": [
             "Massachusetts Land Court"
         ],
@@ -5348,11 +5557,12 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Massachusetts Land Court"
+            "Massachusetts Land Court"
         ],
         "type": "trial",
         "id": "massland",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5373,7 +5583,8 @@
         "court_url": "http://www.mass.gov/courts/court-info/trial-court/dc/",
         "type": "appellate",
         "id": "massdistct",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "Mass. Dist. Ct."
     },
     {
         "regex": [
@@ -5391,7 +5602,9 @@
         ],
         "name": "Massachusetts Supreme Judicial Court",
         "level": "colr",
-        "case_types": ["All"],
+        "case_types": [
+            "All"
+        ],
         "system": "state",
         "examples": [
             "Supreme Court Of Massachusetts",
@@ -5401,7 +5614,8 @@
         "court_url": "http://www.mass.gov/courts/sjc/",
         "type": "appellate",
         "id": "mass",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "Mass."
     },
     {
         "regex": [
@@ -5427,7 +5641,8 @@
         "court_url": "http://www.mad.uscourts.gov/",
         "type": "trial",
         "id": "mad",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "D. Mass."
     },
     {
         "regex": [
@@ -5449,7 +5664,8 @@
         "court_url": "http://www.mab.uscourts.gov/",
         "type": "bankruptcy",
         "id": "mab",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "Bankr. D. Mass."
     },
     {
         "regex": [
@@ -5470,7 +5686,8 @@
         "court_url": "http://courts.mi.gov/courts/coa/pages/default.aspx",
         "type": "appellate",
         "id": "michctapp",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": "Mich. Ct. App."
     },
     {
         "regex": [
@@ -5491,7 +5708,8 @@
         "court_url": "http://courts.mi.gov/",
         "type": "appellate",
         "id": "mich",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": "Mich."
     },
     {
         "regex": [
@@ -5511,12 +5729,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "U S District Court West So Div Dist Mich"
+            "U S District Court West So Div Dist Mich"
         ],
         "court_url": "http://www.miwd.uscourts.gov/",
         "type": "appellate",
         "id": "miwd",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5539,7 +5758,8 @@
         "court_url": "http://www.mied.uscourts.gov/",
         "type": "appellate",
         "id": "mied",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": "E.D. Mich."
     },
     {
         "regex": [
@@ -5560,7 +5780,8 @@
         "examples": [],
         "type": "appellate",
         "id": "michd",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5581,7 +5802,8 @@
         "court_url": "http://www.miwb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "miwb",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": "Bankr. W.D. Mich."
     },
     {
         "regex": [
@@ -5603,7 +5825,8 @@
         "court_url": "http://www.mieb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "mieb",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": "Bankr. E.D. Mich."
     },
     {
         "regex": [
@@ -5620,11 +5843,12 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Minnesota Tax Court"
+            "Minnesota Tax Court"
         ],
         "type": null,
         "id": "mntax",
-        "location": "Minnesota"
+        "location": "Minnesota",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5648,7 +5872,8 @@
         ],
         "type": null,
         "id": "minndistct",
-        "location": "Minnesota"
+        "location": "Minnesota",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5669,7 +5894,8 @@
         "court_url": "http://www.mncourts.gov/?page=551",
         "type": "appellate",
         "id": "minnctapp",
-        "location": "Minnesota"
+        "location": "Minnesota",
+        "citation_string": "Minn. Ct. App."
     },
     {
         "regex": [
@@ -5691,7 +5917,8 @@
         "court_url": "http://www.mncourts.gov/?page=550",
         "type": "appellate",
         "id": "minn",
-        "location": "Minnesota"
+        "location": "Minnesota",
+        "citation_string": "Minn."
     },
     {
         "regex": [
@@ -5716,7 +5943,8 @@
         "court_url": "http://www.mnd.uscourts.gov/",
         "type": "appellate",
         "id": "mnd",
-        "location": "Minnesota"
+        "location": "Minnesota",
+        "citation_string": "D. Minnesota"
     },
     {
         "regex": [
@@ -5738,7 +5966,8 @@
         "court_url": "http://www.mnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "mnb",
-        "location": "Minnesota"
+        "location": "Minnesota",
+        "citation_string": "Bankr. D. Minn."
     },
     {
         "regex": [
@@ -5758,7 +5987,8 @@
         "court_url": "http://courts.ms.gov/appellate_courts/coa/coa.html",
         "type": "appellate",
         "id": "missctapp",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": "Miss. Ct. App."
     },
     {
         "regex": [
@@ -5785,7 +6015,8 @@
         "court_url": "http://courts.ms.gov/appellate_courts/sc/sc.html",
         "type": "appellate",
         "id": "miss",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": "Miss."
     },
     {
         "regex": [
@@ -5809,7 +6040,8 @@
         "court_url": "http://www.msnd.uscourts.gov/",
         "type": "appellate",
         "id": "msnd",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": "N.D. Miss."
     },
     {
         "regex": [
@@ -5817,7 +6049,6 @@
             "${dc} Mississippi",
             "^${d} ?(D)? ?Mississippi",
             "District Court Territory Of Mississippi"
-
         ],
         "dates": [
             {
@@ -5832,7 +6063,8 @@
         "examples": [],
         "type": "appellate",
         "id": "missd",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -5853,7 +6085,8 @@
         "court_url": "http://www.mssd.uscourts.gov/",
         "type": "trial",
         "id": "mssd",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": "S.D. Miss."
     },
     {
         "regex": [
@@ -5874,7 +6107,8 @@
         "court_url": "http://www.msnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "msnb",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": "Bankr. N.D. Miss."
     },
     {
         "regex": [
@@ -5896,7 +6130,8 @@
         "court_url": "http://www.mssb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "mssb",
-        "location": "Mississippi"
+        "location": "Mississippi",
+        "citation_string": "Bankr. S.D. Miss."
     },
     {
         "regex": [
@@ -5928,7 +6163,8 @@
         "court_url": "http://www.courts.mo.gov/page.jsp?id=261",
         "type": "appellate",
         "id": "moctapp",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "Mo. Ct. App."
     },
     {
         "regex": [
@@ -5950,7 +6186,8 @@
         "court_url": "http://www.courts.mo.gov/page.jsp?id=27",
         "type": "appellate",
         "id": "mo",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "Mo."
     },
     {
         "regex": [
@@ -5980,7 +6217,8 @@
         "court_url": "http://www.moed.uscourts.gov/",
         "type": "appellate",
         "id": "moed",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "E.D. Mo."
     },
     {
         "regex": [
@@ -6000,7 +6238,8 @@
         "examples": [],
         "type": "appellate",
         "id": "mod",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6024,7 +6263,8 @@
         "court_url": "http://www.mow.uscourts.gov/",
         "type": "appellate",
         "id": "mowd",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "W.D. Mo."
     },
     {
         "regex": [
@@ -6044,7 +6284,8 @@
         "court_url": "https://www.ago.mo.gov/",
         "type": "ag",
         "id": "moag",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "Mo. Att'y Gen."
     },
     {
         "regex": [
@@ -6066,7 +6307,8 @@
         "court_url": "http://www.moeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "moeb",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "Bankr. E.D. Mo."
     },
     {
         "regex": [
@@ -6087,7 +6329,8 @@
         "court_url": "http://www.mow.uscourts.gov/bankruptcy/",
         "type": "bankruptcy",
         "id": "mowb",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "Bankr. W.D. Mo."
     },
     {
         "regex": [
@@ -6112,7 +6355,8 @@
         ],
         "type": "trial",
         "id": "mtwaterct",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6137,7 +6381,8 @@
         "court_url": "http://courts.mt.gov/supreme/default.mcpx",
         "type": "appellate",
         "id": "mont",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": "Mont."
     },
     {
         "regex": [
@@ -6163,7 +6408,8 @@
         ],
         "type": "trial",
         "id": "mtjdct",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6183,7 +6429,8 @@
         "court_url": "http://mtab.mt.gov/",
         "type": "appellate",
         "id": "monttc",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": "Mont.T.A.B."
     },
     {
         "regex": [
@@ -6206,7 +6453,8 @@
         "court_url": "http://www.mtd.uscourts.gov/",
         "type": "trial",
         "id": "mtd",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": "D. Mont."
     },
     {
         "regex": [
@@ -6227,7 +6475,8 @@
         "court_url": "http://www.mtb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "mtb",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": "Bankr. D. Mont."
     },
     {
         "regex": [
@@ -6248,7 +6497,8 @@
         "court_url": "http://supremecourt.ne.gov/",
         "type": "appellate",
         "id": "nebctapp",
-        "location": "Nebraska"
+        "location": "Nebraska",
+        "citation_string": "Neb. Ct. App."
     },
     {
         "regex": [
@@ -6271,7 +6521,8 @@
         "court_url": "http://supremecourt.ne.gov/",
         "type": "appellate",
         "id": "neb",
-        "location": "Nebraska"
+        "location": "Nebraska",
+        "citation_string": "Neb."
     },
     {
         "regex": [
@@ -6295,7 +6546,8 @@
         "court_url": "http://www.ned.uscourts.gov/",
         "federal_circuit": 8,
         "id": "ned",
-        "location": "Nebraska"
+        "location": "Nebraska",
+        "citation_string": "D. Neb."
     },
     {
         "regex": [
@@ -6315,7 +6567,8 @@
         "court_url": "https://ago.nebraska.gov/",
         "type": "ag",
         "id": "nebag",
-        "location": "Nebraska"
+        "location": "Nebraska",
+        "citation_string": "Neb. Att'y Gen."
     },
     {
         "regex": [
@@ -6336,7 +6589,8 @@
         "court_url": "http://www.neb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nebraskab",
-        "location": "Nebraska"
+        "location": "Nebraska",
+        "citation_string": "Bankr. D. Neb."
     },
     {
         "regex": [
@@ -6359,7 +6613,8 @@
         "court_url": "http://www.nevadajudiciary.us/index.php/supremecourt",
         "type": "appellate",
         "id": "nev",
-        "location": "Nevada"
+        "location": "Nevada",
+        "citation_string": "Nev."
     },
     {
         "regex": [
@@ -6379,7 +6634,8 @@
         "court_url": "",
         "type": "appellate",
         "id": "nev",
-        "location": "Nevada"
+        "location": "Nevada",
+        "citation_string": "Nev."
     },
     {
         "regex": [
@@ -6400,7 +6656,8 @@
         "court_url": "http://www.nvd.uscourts.gov/",
         "type": "appellate",
         "id": "nvd",
-        "location": "Nevada"
+        "location": "Nevada",
+        "citation_string": "D. Nev."
     },
     {
         "regex": [
@@ -6421,7 +6678,8 @@
         "court_url": "http://www.nvb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nvb",
-        "location": "Nevada"
+        "location": "Nevada",
+        "citation_string": "Bankr. D. Nev."
     },
     {
         "regex": [
@@ -6444,9 +6702,10 @@
         "cites": [
             "nh"
         ],
-        "location": "New Hampshire"
+        "location": "New Hampshire",
+        "citation_string": "N.H."
     },
-  {
+    {
         "regex": [
             "Superior Court of New Hampshire",
             "Superior Court Of Judicature Of New Hampshire"
@@ -6465,7 +6724,8 @@
         "examples": [],
         "court_url": "http://www.courts.state.nh.us/supreme/",
         "type": "trial",
-        "location": "New Hampshire"
+        "location": "New Hampshire",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6487,7 +6747,8 @@
         "court_url": "http://www.nhd.uscourts.gov/",
         "type": "trial",
         "id": "nhd",
-        "location": "New Hampshire"
+        "location": "New Hampshire",
+        "citation_string": "D.N.H."
     },
     {
         "regex": [
@@ -6507,7 +6768,8 @@
         "court_url": "http://www.nhb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nhb",
-        "location": "New Hampshire"
+        "location": "New Hampshire",
+        "citation_string": "Bankr. D.N.H."
     },
     {
         "regex": [
@@ -6541,7 +6803,6 @@
             "District Court Burlington County Small Claims Division New Jersey",
             "Circuit Court Of New Jersey",
             "Circuit Court New Jersey",
-
             "Criminal Court Of.* New Jersey",
             "Juvenile Court New Jersey",
             "Juvenile Court Essex County New Jersey",
@@ -6555,7 +6816,6 @@
                 "start": "1830-01-01",
                 "end": "1948-12-31"
             },
-
             {
                 "start": "1947-01-01",
                 "end": null
@@ -6584,7 +6844,8 @@
         "court_url": "http://www.judiciary.state.nj.us/appdiv/index.htm",
         "type": "trial",
         "id": "njsuperctappdiv",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": "N.J. Super. Ct. App. Div."
     },
     {
         "regex": [
@@ -6616,7 +6877,8 @@
         "court_url": "http://www.judiciary.state.nj.us/supreme/",
         "type": "appellate",
         "id": "nj",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": "N.J."
     },
     {
         "regex": [
@@ -6638,7 +6900,8 @@
         ],
         "type": null,
         "id": "njorphct",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6664,14 +6927,14 @@
         ],
         "type": null,
         "id": "njmunict",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": ""
     },
     {
         "regex": [
             "Court Of Common Pleas.* New Jersey",
             "Common Pleas Court New Jersey",
             "Common Pleas.* New Jersey"
-
         ],
         "dates": [
             {
@@ -6688,7 +6951,8 @@
         ],
         "type": null,
         "id": "njctcompl",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6710,9 +6974,10 @@
         ],
         "type": null,
         "id": "njoytermct",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Court Of Oyer And Terminer of Pennsylvania",
             "Court Of Oyer And Terminer At Philadelphia"
@@ -6732,7 +6997,8 @@
         ],
         "type": null,
         "id": "paoytermct",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6765,10 +7031,11 @@
             "Board Of Taxation Hudson County New Jersey",
             "State Of New Jersey State Board Of Taxes And Assessment"
         ],
-        "court_url": "http://www.judiciary.state.nj.us/taxcourt/\u200e",
+        "court_url": "http://www.judiciary.state.nj.us/taxcourt/‎",
         "type": "appellate",
         "id": "njtc",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6791,7 +7058,8 @@
         "court_url": "http://www.njd.uscourts.gov/",
         "type": "appellate",
         "id": "njd",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": "D.N.J."
     },
     {
         "regex": [
@@ -6813,7 +7081,8 @@
         "court_url": "http://www.njb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "njb",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": "Bankr. D.N.J."
     },
     {
         "regex": [
@@ -6834,7 +7103,8 @@
         "court_url": "https://coa.nmcourts.gov/index.php",
         "type": "appellate",
         "id": "nmctapp",
-        "location": "New Mexico"
+        "location": "New Mexico",
+        "citation_string": "N.M. Ct. App."
     },
     {
         "regex": [
@@ -6857,7 +7127,8 @@
         "court_url": "https://nmsupremecourt.nmcourts.gov/index.php",
         "type": "appellate",
         "id": "nm",
-        "location": "New Mexico"
+        "location": "New Mexico",
+        "citation_string": "N.M."
     },
     {
         "regex": [
@@ -6880,7 +7151,8 @@
         "court_url": "http://www.nmcourt.fed.us/web/DCDOCS/dcindex.html",
         "type": "appellate",
         "id": "nmd",
-        "location": "New Mexico"
+        "location": "New Mexico",
+        "citation_string": "D.N.M."
     },
     {
         "regex": [
@@ -6902,7 +7174,8 @@
         "court_url": "http://www.nmb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nmb",
-        "location": "New Mexico"
+        "location": "New Mexico",
+        "citation_string": "Bankr. D.N.M."
     },
     {
         "regex": [
@@ -6928,14 +7201,15 @@
         "case_types": [],
         "system": "state",
         "examples": [
-           "2nd 11th And 13th Judicial Districts",
+            "2nd 11th And 13th Judicial Districts",
             "State Of New York Supreme Court County Of New York Appellate Division First Department Court Of Appeals",
             "Supreme Court Of New York.*Depa"
         ],
         "court_url": "http://www.courts.state.ny.us/courts/appellatedivisions.shtml",
         "type": "appellate",
         "id": "nyappdiv",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "N.Y. App. Div."
     },
     {
         "regex": [
@@ -6965,7 +7239,8 @@
         "examples": [],
         "type": "trial",
         "id": "nygensess",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -6989,7 +7264,8 @@
         ],
         "type": "trial",
         "id": "nysessct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7051,7 +7327,8 @@
         "court_url": "http://www.nycourts.gov/courts/townandvillage/",
         "type": "trial",
         "id": "nytownct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7077,7 +7354,8 @@
         "court_url": "",
         "type": "appellate",
         "id": "nyerrct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [],
@@ -7103,7 +7381,8 @@
         "active": true,
         "type": "appellate",
         "id": "nyimpct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7129,7 +7408,8 @@
         ],
         "type": "trial",
         "id": "nyd",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7165,14 +7445,15 @@
         "court_url": "https://www.nycourts.gov/courts/1jd/supctmanh/appellate_term.shtml",
         "type": "appellate",
         "id": "nyappterm",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "N.Y. App. Term."
     },
     {
         "regex": [
-          "Vice Chancellor S Court Of New York",
-          "Chancellor S Court Of New York",
-          "Chancery Court Of New York",
-          "Court Of Chancery New York"
+            "Vice Chancellor S Court Of New York",
+            "Chancellor S Court Of New York",
+            "Chancery Court Of New York",
+            "Court Of Chancery New York"
         ],
         "dates": [
             {
@@ -7190,7 +7471,8 @@
         ],
         "type": "trial",
         "id": "nychanct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7218,7 +7500,8 @@
         ],
         "type": "trial",
         "id": "superctny",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [],
@@ -7235,7 +7518,8 @@
         "examples": [],
         "type": "trial",
         "id": "nyadmct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [],
@@ -7252,7 +7536,8 @@
         "examples": [],
         "type": "trial",
         "id": "nyproct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7277,7 +7562,8 @@
         ],
         "type": "trial",
         "id": "nycirct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7302,7 +7588,8 @@
         ],
         "type": "trial",
         "id": "nymarct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7343,7 +7630,8 @@
         "court_url": "http://www.nycourts.gov/courts/cts-outside-nyc-COUNTY.shtml",
         "type": "trial",
         "id": "nycountyct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7369,7 +7657,8 @@
         "active": false,
         "type": "trial",
         "id": "nyoytermct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7388,7 +7677,8 @@
         "examples": [],
         "type": "trial",
         "id": "nyjudct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7432,10 +7722,11 @@
             "District Court Nassau City",
             "District Court Nassau Dist Ct"
         ],
-      "court_url": "http://www.nycourts.gov/courts/cts-outside-nyc-DISTRICT.shtml",
+        "court_url": "http://www.nycourts.gov/courts/cts-outside-nyc-DISTRICT.shtml",
         "type": "trial",
         "id": "nydistct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7506,7 +7797,8 @@
         "court_url": "http://www.nycourts.gov/courts/cts-outside-nyc-CITY.shtml",
         "type": "trial",
         "id": "nycityct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7571,7 +7863,8 @@
         "court_url": "http://www.nycourts.gov/courts/cts-outside-nyc-FAMILY.shtml",
         "type": "trial",
         "id": "nyfamct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "N.Y. Fam. Ct."
     },
     {
         "regex": [
@@ -7613,7 +7906,8 @@
         "active": true,
         "type": "trial",
         "id": "nysurgct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7656,7 +7950,8 @@
         ],
         "type": "trial",
         "id": "civctnyc",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7725,7 +8020,8 @@
         ],
         "type": "trial",
         "id": "nyccrimct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7745,7 +8041,8 @@
         "examples": [],
         "type": "trial",
         "id": "nyclaimsct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7780,7 +8077,8 @@
         ],
         "type": "trial",
         "id": "nyctcompl",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [],
@@ -7796,7 +8094,8 @@
         "examples": [],
         "type": "trial",
         "id": "nyprobsolvct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -7829,7 +8128,8 @@
         "court_url": "http://www.nycourts.gov/ctapps/",
         "type": "appellate",
         "id": "ny",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "NY"
     },
     {
         "regex": [
@@ -7924,7 +8224,8 @@
         "court_url": "http://www.nycourts.gov/courts/cts-outside-nyc-SUPREME.shtml",
         "type": "trial",
         "id": "nysupct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "N.Y. Sup. Ct."
     },
     {
         "regex": [
@@ -7968,7 +8269,8 @@
         "court_url": "http://www.nyed.uscourts.gov/",
         "type": "trial",
         "id": "nyed",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "E.D.N.Y"
     },
     {
         "regex": [
@@ -8001,7 +8303,8 @@
         "court_url": "http://www.nynd.uscourts.gov/",
         "type": "appellate",
         "id": "nynd",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8022,7 +8325,8 @@
         "court_url": "http://www.nywd.uscourts.gov/",
         "type": "appellate",
         "id": "nywd",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "W.D.N.Y."
     },
     {
         "regex": [
@@ -8069,7 +8373,8 @@
         "court_url": "http://www.nysd.uscourts.gov/",
         "type": "trial",
         "id": "nysd",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "S.D.N.Y."
     },
     {
         "regex": [
@@ -8089,7 +8394,8 @@
         "court_url": "http://www.ag.ny.gov/",
         "type": "ag",
         "id": "nyag",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "N.Y. Att'y Gen."
     },
     {
         "regex": [
@@ -8110,7 +8416,8 @@
         "court_url": "http://www.nynb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nynb",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "Bankr. N.D.N.Y."
     },
     {
         "regex": [
@@ -8131,7 +8438,8 @@
         "court_url": "http://www.nywb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nywb",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "Bankr. W.D.N.Y."
     },
     {
         "regex": [
@@ -8154,7 +8462,8 @@
         "court_url": "http://www.nysb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nysb",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "Bankr. S.D.N.Y."
     },
     {
         "regex": [
@@ -8176,7 +8485,8 @@
         "court_url": "http://www.nyeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nyeb",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "Bankr. E.D.N.Y."
     },
     {
         "regex": [
@@ -8202,7 +8512,8 @@
         ],
         "type": "special",
         "id": "nyarbct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8236,7 +8547,8 @@
         ],
         "type": "trial",
         "id": "ncd",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8261,7 +8573,8 @@
         "court_url": "http://www.nccourts.org/courts/appellate/supreme/",
         "type": "appellate",
         "id": "nc",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "N.C."
     },
     {
         "regex": [
@@ -8280,12 +8593,13 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "North Carolina Superior Court New Hanover County"
+            "North Carolina Superior Court New Hanover County"
         ],
         "court_url": "http://www.nccourts.org/Courts/Trial/Superior/",
         "type": "appellate",
         "id": "ncsuperct",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "Sup. Ct. N.C."
     },
     {
         "regex": [
@@ -8306,7 +8620,8 @@
         "court_url": "http://www.nccourts.org/courts/appellate/appeal/",
         "type": "appellate",
         "id": "ncctapp",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "N.C. Ct. App."
     },
     {
         "regex": [
@@ -8326,7 +8641,8 @@
         "court_url": "http://www.ic.nc.gov/",
         "type": "appellate",
         "id": "ncworkcompcom",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "N.C. Indus. Comm."
     },
     {
         "regex": [
@@ -8348,7 +8664,8 @@
         "court_url": "http://www.ncwd.uscourts.gov/",
         "type": "appellate",
         "id": "ncwd",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "W.D.N.C."
     },
     {
         "regex": [
@@ -8371,7 +8688,8 @@
         "court_url": "http://www.ncmd.uscourts.gov/",
         "type": "trial",
         "id": "ncmd",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "M.D.N.C."
     },
     {
         "regex": [
@@ -8394,7 +8712,8 @@
         "court_url": "http://www.nced.uscourts.gov/",
         "type": "trial",
         "id": "nced",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "E.D.N.C."
     },
     {
         "regex": [
@@ -8415,7 +8734,8 @@
         "court_url": "http://www.ncwb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ncwb",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "Bankr. W.D.N.C."
     },
     {
         "regex": [
@@ -8436,7 +8756,8 @@
         "court_url": "http://www.ncmb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ncmb",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "Bankr. M.D.N.C."
     },
     {
         "regex": [
@@ -8468,7 +8789,8 @@
         "court_url": "https://ecf.nceb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nceb",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": "Bankr. E.D.N.C."
     },
     {
         "regex": [
@@ -8488,7 +8810,8 @@
         "court_url": "http://www.ndcourts.gov/default.htm",
         "type": "appellate",
         "id": "ndctapp",
-        "location": "North Dakota"
+        "location": "North Dakota",
+        "citation_string": "N.D. Ct. App."
     },
     {
         "regex": [
@@ -8511,9 +8834,10 @@
         "court_url": "http://www.ndcourts.gov/default.htm",
         "type": "appellate",
         "id": "nd",
-        "location": "North Dakota"
+        "location": "North Dakota",
+        "citation_string": "N.D."
     },
-  {
+    {
         "regex": [
             "Supreme Court of Dakota",
             "Supreme Court Of The Territory Of Dakota"
@@ -8534,7 +8858,8 @@
         "active": false,
         "type": "appellate",
         "id": "dakotasup",
-        "location": "Dakota Territory"
+        "location": "Dakota Territory",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8554,7 +8879,8 @@
         "court_url": "http://www.ndd.uscourts.gov/",
         "type": "appellate",
         "id": "ndd",
-        "location": "North Dakota"
+        "location": "North Dakota",
+        "citation_string": "D.N.D."
     },
     {
         "regex": [
@@ -8575,7 +8901,8 @@
         "court_url": "http://www.ndd.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ndb",
-        "location": "North Dakota"
+        "location": "North Dakota",
+        "citation_string": "Bankr. D.N.D."
     },
     {
         "regex": [
@@ -8600,7 +8927,8 @@
         "court_url": "http://www.supremecourt.ohio.gov/",
         "type": "appellate",
         "id": "ohio",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "Ohio"
     },
     {
         "regex": [
@@ -8627,9 +8955,10 @@
         ],
         "type": "trial",
         "id": "ohiocountyct",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Ohio Superior Court",
             "Superior Court Of Ohio",
@@ -8656,9 +8985,10 @@
         ],
         "type": "trial",
         "id": "ohiosuperct",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Magistrate S Court.* ohio"
         ],
@@ -8681,7 +9011,8 @@
         ],
         "type": "trial",
         "id": "ohiomagct",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8705,7 +9036,8 @@
         ],
         "type": "trial",
         "id": "ohiocirct",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8727,7 +9059,8 @@
         "examples": [],
         "type": "trial",
         "id": "ohiodistct",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8758,7 +9091,8 @@
         "court_url": "http://www.supremecourt.ohio.gov/JudSystem/districtCourts/",
         "type": "appellate",
         "id": "ohioctapp",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "Ohio Ct. App."
     },
     {
         "regex": [
@@ -8776,12 +9110,13 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Court Of Claims Victims Of Crime Division State Of Ohio"
+            "Court Of Claims Victims Of Crime Division State Of Ohio"
         ],
         "court_url": "http://www.cco.state.oh.us/",
         "type": "appellate",
         "id": "ohioctcl",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "Ohio Ct. Cl."
     },
     {
         "regex": [
@@ -8835,7 +9170,8 @@
         ],
         "type": "trial",
         "id": "ohioctcompl",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8855,7 +9191,8 @@
         "examples": [],
         "type": "trial",
         "id": "ohjvct",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8887,7 +9224,8 @@
         ],
         "type": "trial",
         "id": "ohmunict",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -8920,7 +9258,8 @@
         "court_url": "http://www.ohnd.uscourts.gov/",
         "type": "trial",
         "id": "ohnd",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "N.D. Ohio"
     },
     {
         "regex": [
@@ -8941,74 +9280,78 @@
         "court_url": "http://www.uscourts.gov/",
         "type": "appellate",
         "id": "ohiod",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "D. Ohio"
     },
-      {
-      "regex": [
-          "Public Utilities Commission Of Ohio",
-          "Ohio Public Utilities Commission"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "Ohio Public Utilities Commission",
-      "level": "",
-      "case_types": [],
-      "system": "state",
-      "examples": [
-        "State Of Ohio Public Utilities Commission"
-      ],
-      "court_url": "",
-      "type": "trial",
-      "id": "ohiopuc",
-      "location": "Ohio"
+    {
+        "regex": [
+            "Public Utilities Commission Of Ohio",
+            "Ohio Public Utilities Commission"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "Ohio Public Utilities Commission",
+        "level": "",
+        "case_types": [],
+        "system": "state",
+        "examples": [
+            "State Of Ohio Public Utilities Commission"
+        ],
+        "court_url": "",
+        "type": "trial",
+        "id": "ohiopuc",
+        "location": "Ohio",
+        "citation_string": ""
     },
-  {
-      "regex": [
-          "Board Of Public Utility Commissioners New Jersey"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "New Jersey Public Utilities Commission",
-      "level": "",
-      "case_types": [],
-      "system": "state",
-      "examples": [
-        "Board Of Public Utility Commissioners New Jersey"
-      ],
-      "court_url": "",
-      "type": "trial",
-      "id": "njpuc",
-      "location": "New Jersey"
+    {
+        "regex": [
+            "Board Of Public Utility Commissioners New Jersey"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "New Jersey Public Utilities Commission",
+        "level": "",
+        "case_types": [],
+        "system": "state",
+        "examples": [
+            "Board Of Public Utility Commissioners New Jersey"
+        ],
+        "court_url": "",
+        "type": "trial",
+        "id": "njpuc",
+        "location": "New Jersey",
+        "citation_string": ""
     },
-  {
-      "regex": [
-          "New Jersey Department Of Labor Workmen S Compensation Bureau"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "New Jersey Department Of Labor Workmen S Compensation Bureau",
-      "level": "ljc",
-      "case_types": [],
-      "system": "state",
-      "examples": [
-        "New Jersey Department Of Labor Workmen S Compensation Bureau"
-      ],
-      "court_url": "",
-      "type": "trial",
-      "id": "njlaborcomp",
-      "location": "New Jersey"
+    {
+        "regex": [
+            "New Jersey Department Of Labor Workmen S Compensation Bureau"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "New Jersey Department Of Labor Workmen S Compensation Bureau",
+        "level": "ljc",
+        "case_types": [],
+        "system": "state",
+        "examples": [
+            "New Jersey Department Of Labor Workmen S Compensation Bureau"
+        ],
+        "court_url": "",
+        "type": "trial",
+        "id": "njlaborcomp",
+        "location": "New Jersey",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9036,7 +9379,8 @@
         "court_url": "http://www.ohsd.uscourts.gov/",
         "type": "trial",
         "id": "ohsd",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "S.D. Ohio"
     },
     {
         "regex": [
@@ -9061,30 +9405,32 @@
         "court_url": "http://www.ohnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ohnb",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "Bankr. N.D. Ohio"
     },
-      {
-      "regex": [
-          "Board Of Commissioners On The Unauthorized Practice Of Law State Of Ohio",
-          "State Of Ohio Board Of Commissioners On The Unauthorized Practice Of Law"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "Board Of Commissioners On The Unauthorized Practice Of Law State Of Ohio",
-      "level": "ljc",
-      "case_types": [],
-      "system": "state",
-      "examples": [
-        "Board Of Commissioners On The Unauthorized Practice Of Law State Of Ohio"
-      ],
-      "court_url": "",
-      "type": "trial",
-      "id": "ohiobar",
-      "location": "Ohio"
+    {
+        "regex": [
+            "Board Of Commissioners On The Unauthorized Practice Of Law State Of Ohio",
+            "State Of Ohio Board Of Commissioners On The Unauthorized Practice Of Law"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "Board Of Commissioners On The Unauthorized Practice Of Law State Of Ohio",
+        "level": "ljc",
+        "case_types": [],
+        "system": "state",
+        "examples": [
+            "Board Of Commissioners On The Unauthorized Practice Of Law State Of Ohio"
+        ],
+        "court_url": "",
+        "type": "trial",
+        "id": "ohiobar",
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9108,7 +9454,8 @@
         "court_url": "http://www.ohsb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "ohsb",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "Bankr. S.D. Ohio"
     },
     {
         "regex": [
@@ -9130,7 +9477,8 @@
         ],
         "type": "special",
         "id": "ohiotax",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9155,7 +9503,8 @@
         ],
         "type": "trial",
         "id": "okd",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9178,7 +9527,8 @@
         "court_url": "http://www.okcca.net/",
         "type": "appellate",
         "id": "oklacrimapp",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Okla. Crim. App."
     },
     {
         "regex": [
@@ -9205,7 +9555,8 @@
         "court_url": "http://www.oscn.net/oscn/schome/start.htm",
         "type": "appellate",
         "id": "okla",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Okla."
     },
     {
         "regex": [
@@ -9231,7 +9582,8 @@
         "court_url": "http://www.oscn.net/oscn/schome/civilappeals.htm",
         "type": "appellate",
         "id": "oklacivapp",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Okla. Civ. App."
     },
     {
         "regex": [
@@ -9253,7 +9605,8 @@
         "court_url": "http://www.oscn.net/applications/oscn/index.asp?ftdb=STOKCSJE&level=1",
         "type": "appellate",
         "id": "oklajeap",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Okla. J.E.A.P."
     },
     {
         "regex": [
@@ -9273,7 +9626,8 @@
         "court_url": "http://en.wikipedia.org/wiki/Oklahoma_Court_on_the_Judiciary",
         "type": "appellate",
         "id": "oklacoj",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Okla. C.O.J."
     },
     {
         "regex": [
@@ -9293,12 +9647,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States District Court For The Westrn District Of Oklahoma"
+            "United States District Court For The Westrn District Of Oklahoma"
         ],
         "court_url": "http://www.uscourts.gov/",
         "type": "appellate",
         "id": "okwd",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "W.D. Okla."
     },
     {
         "regex": [
@@ -9318,7 +9673,8 @@
         "court_url": "http://www.oknd.uscourts.gov/",
         "type": "appellate",
         "id": "oknd",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "N.D. Okla."
     },
     {
         "regex": [
@@ -9338,7 +9694,8 @@
         "court_url": "http://www.oked.uscourts.gov/",
         "type": "trial",
         "id": "oked",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "E.D. Okla."
     },
     {
         "regex": [
@@ -9358,7 +9715,8 @@
         "court_url": "http://www.oscn.net/applications/oscn/Index.asp?ftdb=STOKAG&level=1",
         "type": "ag",
         "id": "oklaag",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Okla. Att’y Gen."
     },
     {
         "regex": [
@@ -9379,7 +9737,8 @@
         "court_url": "http://www.okwb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "okwb",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Bankr. W.D. Okla."
     },
     {
         "regex": [
@@ -9400,7 +9759,8 @@
         "court_url": "http://www.oknb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "oknb",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Bankr. N.D. Okla"
     },
     {
         "regex": [
@@ -9421,7 +9781,8 @@
         "court_url": "http://www.okeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "okeb",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": "Bankr. E.D. Okla."
     },
     {
         "regex": [
@@ -9443,7 +9804,8 @@
         "court_url": "http://courts.oregon.gov/COA/",
         "type": "appellate",
         "id": "orctapp",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": "Or. Ct. App."
     },
     {
         "regex": [
@@ -9463,9 +9825,10 @@
         "court_url": "http://courts.oregon.gov/Tax/Pages/index.aspx",
         "type": "appellate",
         "id": "ortc",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": "Or. T.C."
     },
-  {
+    {
         "regex": [
             "Circuit Court Of ${bw} County Oregon"
         ],
@@ -9482,7 +9845,8 @@
         "examples": [],
         "type": "trial",
         "id": "orcc",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9506,7 +9870,8 @@
         "court_url": "http://www.publications.ojd.state.or.us/Pages/OpinionsSC.aspx",
         "type": "appellate",
         "id": "or",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": "Or."
     },
     {
         "regex": [
@@ -9531,7 +9896,8 @@
         "court_url": "http://www.ord.uscourts.gov/",
         "type": "appellate",
         "id": "ord",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": "D. Or."
     },
     {
         "regex": [
@@ -9552,7 +9918,8 @@
         "court_url": "http://www.orb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "orb",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": "Bankr. D. Or."
     },
     {
         "regex": [
@@ -9584,7 +9951,8 @@
         ],
         "type": null,
         "id": "pactcompl",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9602,10 +9970,11 @@
         "case_types": [],
         "system": "state",
         "examples": [],
-        "court_url": "http://www.pacourts.us/courts/court-of-judicial-discipline\u200e",
+        "court_url": "http://www.pacourts.us/courts/court-of-judicial-discipline‎",
         "type": "appellate",
         "id": "cjdpa",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Ct. Jud. Disc. Pa"
     },
     {
         "regex": [
@@ -9624,7 +9993,8 @@
         "examples": [],
         "type": "trial",
         "id": "pacirct",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9651,7 +10021,8 @@
         "cites": [
             "Pa."
         ],
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Pa."
     },
     {
         "regex": [
@@ -9672,7 +10043,8 @@
         "court_url": "http://www.pacourts.us/courts/superior-court/",
         "type": "appellate",
         "id": "pasuperct",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Pa. Super. Ct."
     },
     {
         "regex": [
@@ -9697,7 +10069,8 @@
         "court_url": "http://www.pacourts.us/courts/commonwealth-court/",
         "type": "appellate",
         "id": "pacommwct",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Pa. Commw. Ct."
     },
     {
         "regex": [
@@ -9739,7 +10112,8 @@
         "court_url": "http://www.paed.uscourts.gov/",
         "type": "appellate",
         "id": "paed",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "E.D. Pa."
     },
     {
         "regex": [
@@ -9763,7 +10137,8 @@
         "court_url": "http://www.uscourts.gov/",
         "type": "appellate",
         "id": "pennsylvaniad",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "D. Pa."
     },
     {
         "regex": [
@@ -9790,7 +10165,8 @@
         "court_url": "http://www.pamd.uscourts.gov/",
         "type": "appellate",
         "id": "pamd",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "M.D. Penn."
     },
     {
         "regex": [
@@ -9811,13 +10187,14 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States District Court For The Westernd District Of Pennsylvania",
-          "United States District Court For The Western Of Pennsylvania"
+            "United States District Court For The Westernd District Of Pennsylvania",
+            "United States District Court For The Western Of Pennsylvania"
         ],
         "court_url": "http://www.pawd.uscourts.gov/",
         "type": "trial",
         "id": "pawd",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "W.D. Pa."
     },
     {
         "regex": [
@@ -9838,7 +10215,8 @@
         "court_url": "http://www.paeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "paeb",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Bankr. E.D. Pa."
     },
     {
         "regex": [
@@ -9859,7 +10237,8 @@
         "court_url": "http://www.pamb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "pamb",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Bankr. M.D. Penn."
     },
     {
         "regex": [
@@ -9880,7 +10259,8 @@
         "court_url": "http://www.pawb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "pawb",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "Bankr. W.D. Pa."
     },
     {
         "regex": [
@@ -9916,31 +10296,33 @@
         ],
         "type": "appellate",
         "id": "prapp",
-        "location": "Puerto Rico"
+        "location": "Puerto Rico",
+        "citation_string": ""
     },
     {
-      "regex": [
-        "Tribunal Supremo De Puerto Rico",
-        "Tribunal Supremo Of Puerto Rico",
-        "Supremo Tribunal De Puerto Rico"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "Supreme Court of Puerto Rico",
-      "level": "colr",
-      "case_types": [],
-      "system": "state",
-      "examples": [
-        "Tribunal Supremo Of Puerto Rico",
-        "Tribunal Supremo De Puerto Rico0"
-      ],
-      "type": "appellate",
-      "id": "prsupreme",
-      "location": "Puerto Rico"
+        "regex": [
+            "Tribunal Supremo De Puerto Rico",
+            "Tribunal Supremo Of Puerto Rico",
+            "Supremo Tribunal De Puerto Rico"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "Supreme Court of Puerto Rico",
+        "level": "colr",
+        "case_types": [],
+        "system": "state",
+        "examples": [
+            "Tribunal Supremo Of Puerto Rico",
+            "Tribunal Supremo De Puerto Rico0"
+        ],
+        "type": "appellate",
+        "id": "prsupreme",
+        "location": "Puerto Rico",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -9963,7 +10345,8 @@
         "court_url": "http://www.courts.ri.gov/courts/supremecourt/default.aspx",
         "type": "appellate",
         "id": "ri",
-        "location": "Rhode Island"
+        "location": "Rhode Island",
+        "citation_string": "R.I."
     },
     {
         "regex": [
@@ -9987,7 +10370,8 @@
         "court_url": "https://www.courts.ri.gov/Courts/SuperiorCourt/Pages/default.aspx",
         "type": "appellate",
         "id": "risuperct",
-        "location": "Rhode Island"
+        "location": "Rhode Island",
+        "citation_string": "Sup. Ct. R.I."
     },
     {
         "regex": [
@@ -10010,7 +10394,8 @@
         "court_url": "http://www.rid.uscourts.gov/",
         "type": "trial",
         "id": "rid",
-        "location": "Rhode Island"
+        "location": "Rhode Island",
+        "citation_string": "D.R.I."
     },
     {
         "regex": [
@@ -10032,9 +10417,10 @@
         "court_url": "http://www.rib.uscourts.gov/",
         "type": "bankruptcy",
         "id": "rib",
-        "location": "Rhode Island"
+        "location": "Rhode Island",
+        "citation_string": "Bankr. D.R.I."
     },
-  {
+    {
         "regex": [
             "Common Pleas Court Of South Carolina"
         ],
@@ -10052,7 +10438,8 @@
         "court_url": "http://www.judicial.state.sc.us/appeals/",
         "type": "trial",
         "id": "scctcompl",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -10073,7 +10460,8 @@
         "court_url": "http://www.judicial.state.sc.us/appeals/",
         "type": "appellate",
         "id": "scctapp",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": "S.C. Ct. App."
     },
     {
         "regex": [
@@ -10096,7 +10484,8 @@
         "court_url": "http://www.judicial.state.sc.us/supreme/",
         "type": "appellate",
         "id": "sc",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": "S.C."
     },
     {
         "regex": [
@@ -10113,11 +10502,11 @@
                 "notes": "subdivided",
                 "end": "1823-02-21"
             },
-          {
-            "start" : "1965-10-07",
-            "end": "",
-            "notes": "recombined"
-          }
+            {
+                "start": "1965-10-07",
+                "end": "",
+                "notes": "recombined"
+            }
         ],
         "name": "District Court, D. South Carolina",
         "level": "",
@@ -10129,12 +10518,12 @@
             "United States District Court For South Carolina Beaufort Division",
             "United States District Court D Sourth Carolina Columbia Division",
             "United States District Court Florence Division Of South Carolina"
-
         ],
         "court_url": "http://www.scd.uscourts.gov/",
         "type": "appellate",
         "id": "scd",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": "D.S.C."
     },
     {
         "regex": [
@@ -10154,7 +10543,8 @@
         "court_url": "http://www.scd.uscourts.gov/",
         "type": "appellate",
         "id": "southcarolinaed",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": "E.D.S.C."
     },
     {
         "regex": [
@@ -10174,7 +10564,8 @@
         "court_url": "http://www.scd.uscourts.gov/",
         "type": "trial",
         "id": "southcarolinawd",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": "W.D.S.C."
     },
     {
         "regex": [
@@ -10196,7 +10587,8 @@
         "court_url": "http://www.scb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "scb",
-        "location": "South Carolina"
+        "location": "South Carolina",
+        "citation_string": "Bankr. D.S.C."
     },
     {
         "regex": [
@@ -10225,7 +10617,8 @@
         "court_url": "http://www.sdjudicial.com/",
         "type": "appellate",
         "id": "sd",
-        "location": "South Dakota"
+        "location": "South Dakota",
+        "citation_string": "S.D."
     },
     {
         "regex": [
@@ -10248,12 +10641,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States District Court For The Central District Of South Dakota"
+            "United States District Court For The Central District Of South Dakota"
         ],
         "court_url": "http://www.sdd.uscourts.gov/",
         "type": "trial",
         "id": "sdd",
-        "location": "South Dakota"
+        "location": "South Dakota",
+        "citation_string": "D.S.D."
     },
     {
         "regex": [
@@ -10274,7 +10668,8 @@
         "court_url": "https://ecf.sdb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "sdb",
-        "location": "South Dakota"
+        "location": "South Dakota",
+        "citation_string": "Bankr. D.S.D."
     },
     {
         "regex": [
@@ -10296,7 +10691,8 @@
         "court_url": "https://www.tncourts.gov/courts/supreme-court",
         "type": "appellate",
         "id": "tenn",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Tenn."
     },
     {
         "regex": [
@@ -10317,7 +10713,8 @@
         "court_url": "http://www.tsc.state.tn.us/courts/court-criminal-appeals",
         "type": "appellate",
         "id": "tenncrimapp",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Tenn. Crim. App."
     },
     {
         "regex": [
@@ -10339,37 +10736,39 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Court Of Chancery Appeals Of Tennessee",
-          "Court Of Appeals At Tennessee Western Section At Nashville"
+            "Court Of Chancery Appeals Of Tennessee",
+            "Court Of Appeals At Tennessee Western Section At Nashville"
         ],
         "court_url": "http://www.tncourts.gov/courts/court-appeals",
         "type": "appellate",
         "id": "tennctapp",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Tenn. Ct. App."
     },
     {
-      "regex": [
-          "Tennessee Special Workers Compensation Appeals Panel",
-          "Supreme Court Of Tennessee Special Workers Compensation Appeals Panel",
-          "Tennessee Workers Compensation Appeals Panel"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "Tennessee Special Workers Compensation Appeals Panel",
-      "level": "",
-      "case_types": [],
-      "system": "state",
-      "examples": [
-        "Tennessee Special Workers Compensation Appeals Panel"
-      ],
-      "court_url": "",
-      "type": "trial",
-      "id": "tennworkcompapp",
-      "location": "Tennessee"
+        "regex": [
+            "Tennessee Special Workers Compensation Appeals Panel",
+            "Supreme Court Of Tennessee Special Workers Compensation Appeals Panel",
+            "Tennessee Workers Compensation Appeals Panel"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "Tennessee Special Workers Compensation Appeals Panel",
+        "level": "",
+        "case_types": [],
+        "system": "state",
+        "examples": [
+            "Tennessee Special Workers Compensation Appeals Panel"
+        ],
+        "court_url": "",
+        "type": "trial",
+        "id": "tennworkcompapp",
+        "location": "Tennessee",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -10394,7 +10793,8 @@
         "court_url": "http://www.tnwd.uscourts.gov/",
         "type": "trial",
         "id": "tnwd",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "W.D. Tenn."
     },
     {
         "regex": [
@@ -10415,7 +10815,8 @@
         "court_url": "http://www.uscourts.gov/",
         "type": "trial",
         "id": "tennessed",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "D. Tenn."
     },
     {
         "regex": [
@@ -10437,7 +10838,8 @@
         "court_url": "http://www.tnmd.uscourts.gov/",
         "type": "trial",
         "id": "tnmd",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "M.D. Tenn."
     },
     {
         "regex": [
@@ -10457,12 +10859,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States District Court For The Eastern District Of At Knoxville Tennessee"
+            "United States District Court For The Eastern District Of At Knoxville Tennessee"
         ],
         "court_url": "http://www.tned.uscourts.gov/",
         "type": "trial",
         "id": "tned",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "E.D. Tenn."
     },
     {
         "regex": [
@@ -10484,7 +10887,8 @@
         "court_url": "http://www.tnwb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "tnwb",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Bankr. W.D. Tenn."
     },
     {
         "regex": [
@@ -10507,7 +10911,8 @@
         "court_url": "http://www.tnmb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "tnmb",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Bankr. M.D. Tenn."
     },
     {
         "regex": [
@@ -10528,7 +10933,8 @@
         "court_url": "http://www.tneb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "tneb",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Bankr. E.D. Tenn."
     },
     {
         "regex": [
@@ -10549,7 +10955,8 @@
         "court_url": "http://www.fjc.gov/history/home.nsf/page/courts_district_tn_mp.html",
         "type": "bankruptcy",
         "id": "tennesseeb",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "Bankr. D. Tenn."
     },
     {
         "regex": [
@@ -10570,7 +10977,8 @@
         "court_url": "http://www.scjc.state.tx.us/",
         "type": "appellate",
         "id": "texreview",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Tex. Rev."
     },
     {
         "regex": [
@@ -10593,7 +11001,8 @@
         "court_url": "http://www.supreme.courts.state.tx.us/",
         "type": "appellate",
         "id": "tex",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Tex."
     },
     {
         "regex": [
@@ -10614,7 +11023,8 @@
         "court_url": "http://www.txcourts.gov/about-texas-courts/multi-district-litigation-panel.aspx",
         "type": "appellate",
         "id": "texjpml",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Tex. J.P.M.L."
     },
     {
         "regex": [
@@ -10658,7 +11068,8 @@
         "court_url": "http://www.courts.state.tx.us/courts/coa.asp",
         "type": "appellate",
         "id": "texapp",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Tex. App."
     },
     {
         "regex": [
@@ -10681,7 +11092,8 @@
         "court_url": "http://www.cca.courts.state.tx.us/",
         "type": "appellate",
         "id": "texcrimapp",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Tex. Crim. App."
     },
     {
         "regex": [
@@ -10701,7 +11113,8 @@
         "examples": [],
         "type": "appellate",
         "id": "texd",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -10723,12 +11136,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States District Court For The Western Of District Texas Austin Division"
+            "United States District Court For The Western Of District Texas Austin Division"
         ],
         "court_url": "http://www.txwd.uscourts.gov/",
         "type": "appellate",
         "id": "txwd",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "W.D. Tex."
     },
     {
         "regex": [
@@ -10748,7 +11162,8 @@
         "court_url": "http://www.txed.uscourts.gov/",
         "type": "trial",
         "id": "txed",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "E.D. Tex."
     },
     {
         "regex": [
@@ -10774,7 +11189,8 @@
         "court_url": "http://www.txs.uscourts.gov/",
         "type": "trial",
         "id": "txsd",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "S.D. Tex."
     },
     {
         "regex": [
@@ -10798,7 +11214,8 @@
         "court_url": "http://www.txnd.uscourts.gov/",
         "type": "trial",
         "id": "txnd",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "N.D. Tex."
     },
     {
         "regex": [
@@ -10818,7 +11235,8 @@
         "court_url": "https://texasattorneygeneral.gov/",
         "type": "ag",
         "id": "texag",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Tex. Att'y Gen."
     },
     {
         "regex": [
@@ -10840,7 +11258,8 @@
         "court_url": "http://www.txwd.uscourts.gov/",
         "type": "bankruptcy",
         "id": "txwb",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Bankr. W.D. Tex."
     },
     {
         "regex": [
@@ -10861,7 +11280,8 @@
         "court_url": "http://www.txeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "txeb",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Bankr. E.D. Tex."
     },
     {
         "regex": [
@@ -10883,7 +11303,8 @@
         "court_url": "http://www.txs.uscourts.gov/bankruptcy/",
         "type": "bankruptcy",
         "id": "txsb",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Bankr. S.D. Tex."
     },
     {
         "regex": [
@@ -10904,7 +11325,8 @@
         "court_url": "http://www.txnb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "txnb",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Bankr. N.D. Tex."
     },
     {
         "regex": [
@@ -10925,7 +11347,8 @@
         "court_url": "http://www.txwb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "txwb",
-        "location": "Texas"
+        "location": "Texas",
+        "citation_string": "Bankr. W.D. Tex."
     },
     {
         "regex": [
@@ -10946,7 +11369,8 @@
         "court_url": "http://www.utcourts.gov/courts/appell/",
         "type": "appellate",
         "id": "utahctapp",
-        "location": "Utah"
+        "location": "Utah",
+        "citation_string": "Utah Ct. App."
     },
     {
         "regex": [
@@ -10969,7 +11393,8 @@
         "court_url": "http://www.utcourts.gov/opinions/supopin/index.htm",
         "type": "appellate",
         "id": "utah",
-        "location": "Utah"
+        "location": "Utah",
+        "citation_string": "Utah"
     },
     {
         "regex": [
@@ -10998,7 +11423,8 @@
         "court_url": "http://www.utd.uscourts.gov/",
         "type": "trial",
         "id": "utd",
-        "location": "Utah"
+        "location": "Utah",
+        "citation_string": "D. Utah"
     },
     {
         "regex": [
@@ -11020,7 +11446,8 @@
         "court_url": "http://www.utb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "utb",
-        "location": "Utah"
+        "location": "Utah",
+        "citation_string": "Bankr. D. Utah"
     },
     {
         "regex": [
@@ -11044,7 +11471,8 @@
         "cites": [
             "Vt"
         ],
-        "location": "Vermont"
+        "location": "Vermont",
+        "citation_string": "Vt."
     },
     {
         "regex": [
@@ -11064,7 +11492,8 @@
         "examples": [],
         "court_url": "http://www.vermontjudiciary.org/gtc/supreme/default.aspx",
         "type": "trial",
-        "location": "Vermont"
+        "location": "Vermont",
+        "citation_string": "Vt."
     },
     {
         "regex": [
@@ -11088,7 +11517,8 @@
         "court_url": "http://www.vtd.uscourts.gov/",
         "type": "appellate",
         "cites": [],
-        "location": "Vermont"
+        "location": "Vermont",
+        "citation_string": "D. Vt."
     },
     {
         "regex": [
@@ -11111,7 +11541,8 @@
         "court_url": "http://www.vtb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "vtb",
-        "location": "Vermont"
+        "location": "Vermont",
+        "citation_string": "Bankr. D. Vt."
     },
     {
         "regex": [
@@ -11142,7 +11573,8 @@
         ],
         "type": "trial",
         "id": "vad",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11166,7 +11598,8 @@
         "court_url": "http://www.courts.state.va.us/courts/cav/",
         "type": "appellate",
         "id": "vactapp",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "Va. Ct. App."
     },
     {
         "regex": [
@@ -11199,7 +11632,8 @@
         ],
         "type": "trial",
         "id": "vacc",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11223,9 +11657,10 @@
         ],
         "type": "trial",
         "id": "vacorpct",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Chancery Court Of The City Of Richmond Virginia",
             "Law And Chancery Court Of The City Of Norfolk Virginia",
@@ -11246,7 +11681,8 @@
         ],
         "type": "trial",
         "id": "vachanct",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11268,7 +11704,8 @@
         "court_url": "http://www.courts.state.va.us/courts/scv/",
         "type": "appellate",
         "id": "va",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "Va."
     },
     {
         "regex": [
@@ -11300,7 +11737,8 @@
         "court_url": "http://www.vaed.uscourts.gov/",
         "type": "appellate",
         "id": "vaed",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "E.D. Va."
     },
     {
         "regex": [
@@ -11326,7 +11764,8 @@
         "court_url": "http://www.vawd.uscourts.gov/",
         "type": "trial",
         "id": "vawd",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "W.D. Va."
     },
     {
         "regex": [
@@ -11348,7 +11787,8 @@
         "court_url": "https://www.vaeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "vaeb",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "Bankr. E.D. Va."
     },
     {
         "regex": [
@@ -11370,7 +11810,8 @@
         "court_url": "http://www.vawb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "vawb",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "Bankr. W.D. Va."
     },
     {
         "regex": [
@@ -11394,7 +11835,8 @@
         ],
         "type": "trial",
         "id": "washd",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11404,7 +11846,6 @@
             "State Of Washington Intermediate Court Of Appeals",
             "Court Of Appeals Washington",
             "Courts Of Appeals Of Washington"
-
         ],
         "dates": [
             {
@@ -11422,7 +11863,8 @@
         "court_url": "https://www.courts.wa.gov/appellate_trial_courts/",
         "type": "appellate",
         "id": "washctapp",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "Wash. Ct. App."
     },
     {
         "regex": [
@@ -11455,7 +11897,8 @@
         "court_url": "https://www.courts.wa.gov/appellate_trial_courts/SupremeCourt/",
         "type": "appellate",
         "id": "wash",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "Wash."
     },
     {
         "regex": [
@@ -11484,7 +11927,8 @@
         "court_url": "http://www.wawd.uscourts.gov/",
         "type": "appellate",
         "id": "wawd",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "W.D. Wash."
     },
     {
         "regex": [
@@ -11511,7 +11955,8 @@
         "court_url": "http://www.waed.uscourts.gov/",
         "type": "trial",
         "id": "waed",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "E.D. Wash."
     },
     {
         "regex": [
@@ -11531,7 +11976,8 @@
         "court_url": "http://www.atg.wa.gov/",
         "type": "ag",
         "id": "washag",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "Wash. Att'y Gen."
     },
     {
         "regex": [
@@ -11552,7 +11998,8 @@
         "court_url": "http://www.wawb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "wawb",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "Bankr. W.D. Wash."
     },
     {
         "regex": [
@@ -11573,7 +12020,8 @@
         "court_url": "http://www.waeb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "waeb",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": "Bankr. E.D. Wash."
     },
     {
         "regex": [
@@ -11604,7 +12052,8 @@
         "cites": [
             "U.S."
         ],
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "SCOTUS"
     },
     {
         "regex": [
@@ -11626,7 +12075,8 @@
         "court_url": "http://www.courtswv.gov/supreme-court/",
         "type": "appellate",
         "id": "wva",
-        "location": "West Virginia"
+        "location": "West Virginia",
+        "citation_string": "W. Va."
     },
     {
         "regex": [
@@ -11646,12 +12096,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States District Court S D W Va Huntington Division"
+            "United States District Court S D W Va Huntington Division"
         ],
         "court_url": "http://www.wvsd.uscourts.gov/",
         "type": "appellate",
         "id": "wvsd",
-        "location": "West Virginia"
+        "location": "West Virginia",
+        "citation_string": "S.D.W. Va"
     },
     {
         "regex": [
@@ -11674,7 +12125,8 @@
         ],
         "type": "appellate",
         "id": "wvad",
-        "location": "West Virginia"
+        "location": "West Virginia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11697,7 +12149,8 @@
         "court_url": "http://www.wvnd.uscourts.gov/",
         "type": "trial",
         "id": "wvnd",
-        "location": "West Virginia"
+        "location": "West Virginia",
+        "citation_string": "N.D.W. Va."
     },
     {
         "regex": [
@@ -11719,7 +12172,8 @@
         "court_url": "http://www.wvsb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "wvsb",
-        "location": "West Virginia"
+        "location": "West Virginia",
+        "citation_string": "Bankr. S.D.W. Va."
     },
     {
         "regex": [
@@ -11740,7 +12194,8 @@
         "court_url": "http://www.wvnd.uscourts.gov/",
         "type": "bankruptcy",
         "id": "wvnb",
-        "location": "West Virginia"
+        "location": "West Virginia",
+        "citation_string": "Bankr. N.D.W. Va."
     },
     {
         "regex": [
@@ -11764,7 +12219,8 @@
         "court_url": "http://www.wicourts.gov/courts/appeals/",
         "type": "appellate",
         "id": "wisctapp",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "Wis. Ct. App."
     },
     {
         "regex": [
@@ -11786,7 +12242,8 @@
         "court_url": "http://www.wicourts.gov/courts/supreme/index.htm",
         "type": "appellate",
         "id": "wis",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "Wis."
     },
     {
         "regex": [
@@ -11806,9 +12263,10 @@
         "examples": [],
         "type": "trial",
         "id": "wismunict",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "State Of Wisconsin Circuit Court",
             "State Of Wisconsin Circuit Court Of Waukesha County"
@@ -11824,11 +12282,12 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "State Of Wisconsin Circuit Court Of Waukesha County"
+            "State Of Wisconsin Circuit Court Of Waukesha County"
         ],
         "type": "trial",
         "id": "wisccirct",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11853,7 +12312,8 @@
         "court_url": "http://www.wied.uscourts.gov/",
         "type": "appellate",
         "id": "wied",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "D. Wis."
     },
     {
         "regex": [
@@ -11873,7 +12333,8 @@
         "examples": [],
         "type": "trial",
         "id": "wisd",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -11894,7 +12355,8 @@
         "court_url": "http://www.wiwd.uscourts.gov/",
         "type": "trial",
         "id": "wiwd",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "W.D. Wis."
     },
     {
         "regex": [
@@ -11914,7 +12376,8 @@
         "court_url": "https://docs.legis.wisconsin.gov/misc/oag",
         "type": "ag",
         "id": "wisag",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "Wis. Att'y Gen."
     },
     {
         "regex": [
@@ -11935,7 +12398,8 @@
         "court_url": "http://www.wieb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "wieb",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "Bankr. E.D. Wis."
     },
     {
         "regex": [
@@ -11956,7 +12420,8 @@
         "court_url": "http://www.wiwb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "wiwb",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": "Bankr. W.D. Wis."
     },
     {
         "regex": [
@@ -11978,7 +12443,8 @@
         "court_url": "http://www.courts.state.wy.us/",
         "type": "appellate",
         "id": "wyo",
-        "location": "Wyoming"
+        "location": "Wyoming",
+        "citation_string": "Wyo."
     },
     {
         "regex": [
@@ -12021,7 +12487,8 @@
         "court_url": "http://www.ca11.uscourts.gov/",
         "type": "appellate",
         "id": "ca11",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": "11th Cir."
     },
     {
         "regex": [
@@ -12045,7 +12512,8 @@
         "active": true,
         "type": "special",
         "id": "hopitr",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -12069,12 +12537,11 @@
         "active": true,
         "type": "special",
         "id": "hopiappct",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
-
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Chehalis Tribal Ct. of App.",
         "dates": [
             {
@@ -12093,11 +12560,11 @@
         "active": true,
         "type": "special",
         "id": "chehctapp",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Cherokee Nation Sup. Ct.",
         "dates": [
             {
@@ -12117,11 +12584,11 @@
         "active": true,
         "type": "special",
         "id": "cherokee",
-        "location": "Oklahoma"
+        "location": "Oklahoma",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Chitimacha Ct. of App.",
         "dates": [
             {
@@ -12140,11 +12607,11 @@
         "active": true,
         "type": "special",
         "id": "chitctapp",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Colville Confederated Ct. of App.",
         "dates": [
             {
@@ -12163,11 +12630,11 @@
         "active": true,
         "type": "special",
         "id": "colvctapp",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Confederated Tribes of the Coos, Lower Umpqua & Siuslaw Indians Tribal Ct.",
         "dates": [
             {
@@ -12186,11 +12653,11 @@
         "active": true,
         "type": "special",
         "id": "coosct",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Coquille Indian Tribal Ct.",
         "dates": [
             {
@@ -12209,11 +12676,11 @@
         "active": true,
         "type": "special",
         "id": "coquct",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Coushatta Tribal Ct.",
         "dates": [
             {
@@ -12232,11 +12699,11 @@
         "active": true,
         "type": "special",
         "id": "coushct",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Crow App. Ct.",
         "dates": [
             {
@@ -12255,11 +12722,11 @@
         "active": true,
         "type": "special",
         "id": "crowctapp",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Eastern Band of Cherokee Sup. Ct.",
         "dates": [
             {
@@ -12278,11 +12745,11 @@
         "active": true,
         "type": "special",
         "id": "echerkokee",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": ""
     },
     {
-        "regex": [
-        ],
+        "regex": [],
         "name_abbreviation": "E. Band of Cherokee Tribal Ct.",
         "dates": [
             {
@@ -12301,11 +12768,11 @@
         "active": true,
         "type": "special",
         "id": "echerokeect",
-        "location": "North Carolina"
+        "location": "North Carolina",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Fort McDowell Sup. Ct.",
         "dates": [
             {
@@ -12324,11 +12791,11 @@
         "active": true,
         "type": "special",
         "id": "ftmcdowell",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Fort McDowell Tribal Ct.",
         "dates": [
             {
@@ -12347,11 +12814,11 @@
         "active": true,
         "type": "special",
         "id": "ftmcdowct",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Fort McDowell Tribal Ct. of App.",
         "dates": [
             {
@@ -12370,11 +12837,11 @@
         "active": true,
         "type": "special",
         "id": "ftmcdowctapp",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Fort Peck App. Ct.",
         "dates": [
             {
@@ -12393,11 +12860,11 @@
         "court_url": "https://fptc.org",
         "type": "special",
         "id": "ftpeckctapp",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Grand Ronde Ct. of App.",
         "dates": [
             {
@@ -12416,11 +12883,11 @@
         "active": true,
         "type": "special",
         "id": "grrondectapp",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Grand Ronde Tribal Ct.",
         "dates": [
             {
@@ -12439,11 +12906,11 @@
         "active": true,
         "type": "special",
         "id": "grrondect",
-        "location": "Oregon"
+        "location": "Oregon",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Grand Traverse Band of Ottawa & Chippewa Indians Tribal App. Ct.",
         "dates": [
             {
@@ -12462,11 +12929,11 @@
         "active": true,
         "type": "special",
         "id": "grtravbandctapp",
-        "location": "Michigan"
+        "location": "Michigan",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Ho-Chunk Nation Sup. Ct.",
         "dates": [
             {
@@ -12485,11 +12952,11 @@
         "active": true,
         "type": "special",
         "id": "hochunk",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Ho-Chunk Nation Trial Ct.",
         "dates": [
             {
@@ -12508,11 +12975,11 @@
         "active": true,
         "type": "special",
         "id": "hochunkct",
-        "location": "Wisconsin"
+        "location": "Wisconsin",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Hualapai Ct. of App.",
         "dates": [
             {
@@ -12531,11 +12998,11 @@
         "active": true,
         "type": "special",
         "id": "hualactapp",
-        "location": "Nevada"
+        "location": "Nevada",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Little River Band of Ottawa Indians Tribal Ct.",
         "dates": [
             {
@@ -12554,10 +13021,11 @@
         "active": true,
         "type": "special",
         "id": "lrbottawact",
-        "location": "Michigan"
-    },{
-        "regex": [
-        ],
+        "location": "Michigan",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Little Traverse Bay Bands of Odawa Indians Tribal App. Ct.",
         "dates": [
             {
@@ -12576,10 +13044,11 @@
         "active": true,
         "type": "special",
         "id": "odawactapp",
-        "location": "Michigan"
-    },{
-        "regex": [
-        ],
+        "location": "Michigan",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Makah Tribal Ct.",
         "dates": [
             {
@@ -12598,10 +13067,11 @@
         "active": true,
         "type": "special",
         "id": "makahct",
-        "location": "Washington"
-    },{
-        "regex": [
-        ],
+        "location": "Washington",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Mashantucket Pequot Ct. of App.",
         "dates": [
             {
@@ -12620,11 +13090,11 @@
         "active": true,
         "type": "special",
         "id": "pequotctapp",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Mashantucket Pequot Tribal Ct.",
         "dates": [
             {
@@ -12643,11 +13113,11 @@
         "active": true,
         "type": "special",
         "id": "pequotct",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Mille Lacs Band of Ojibwe Ct. of App.",
         "dates": [
             {
@@ -12667,10 +13137,11 @@
         "active": true,
         "type": "special",
         "id": "ojibwectapp",
-        "location": "Minnesota"
-    },{
-        "regex": [
-        ],
+        "location": "Minnesota",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Mohegan Gaming Disputes Ct. of App.",
         "dates": [
             {
@@ -12689,10 +13160,11 @@
         "active": true,
         "type": "special",
         "id": "mohegangctapp",
-        "location": "Connecticut"
-    },{
-        "regex": [
-        ],
+        "location": "Connecticut",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Mohegan Gaming Disputes Trial Ct.",
         "dates": [
             {
@@ -12711,10 +13183,11 @@
         "active": true,
         "type": "special",
         "id": "mohegangct",
-        "location": "Connecticut"
-    },{
-        "regex": [
-        ],
+        "location": "Connecticut",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Mohegan Trial Ct.",
         "dates": [
             {
@@ -12733,10 +13206,11 @@
         "active": true,
         "type": "special",
         "id": "moheganct",
-        "location": "Connecticut"
-    },{
-        "regex": [
-        ],
+        "location": "Connecticut",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Mohegan Tribal Ct. of App.",
         "dates": [
             {
@@ -12755,11 +13229,11 @@
         "active": true,
         "type": "special",
         "id": "moheganctapp",
-        "location": "Connecticut"
+        "location": "Connecticut",
+        "citation_string": ""
     },
     {
-        "regex": [
-        ],
+        "regex": [],
         "name_abbreviation": "Muscogee (Creek) Nation Sup. Ct.",
         "dates": [
             {
@@ -12778,10 +13252,11 @@
         "court_url": "http://www.creeksupremecourt.com/index.php/case-law",
         "type": "special",
         "id": "muscogee",
-        "location": "Oklahoma"
-    },{
-        "regex": [
-        ],
+        "location": "Oklahoma",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Dist. Ct. of the Navajo Nation",
         "dates": [
             {
@@ -12800,10 +13275,11 @@
         "court_url": "http://www.navajocourts.org/indexsuct.htm",
         "type": "special",
         "id": "navajodistct",
-        "location": "Arizona"
-    },{
-        "regex": [
-        ],
+        "location": "Arizona",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Navajo Ct. of App.",
         "dates": [
             {
@@ -12823,11 +13299,11 @@
         "active": true,
         "type": "special",
         "id": "navajoctapp",
-        "location": "Arizona"
+        "location": "Arizona",
+        "citation_string": ""
     },
     {
-        "regex": [
-        ],
+        "regex": [],
         "name_abbreviation": "Navajo Nation Sup. Ct.",
         "dates": [
             {
@@ -12846,10 +13322,11 @@
         "court_url": "http://www.navajocourts.org/indexsuct.htm",
         "type": "special",
         "id": "navajo",
-        "location": "Arizona"
-    },{
-        "regex": [
-        ],
+        "location": "Arizona",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Northern Plains Intertribal Ct. of App.",
         "dates": [
             {
@@ -12868,10 +13345,11 @@
         "active": true,
         "type": "special",
         "id": "nplainsctapp",
-        "location": "South Dakota"
-    },{
-        "regex": [
-        ],
+        "location": "South Dakota",
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "Oneida App. Comm'n, App. Ct.",
         "dates": [
             {
@@ -12890,11 +13368,11 @@
         "active": true,
         "type": "special",
         "id": "oneidactapp",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Oneida App. Comm'n, Trial Ct.",
         "dates": [
             {
@@ -12913,11 +13391,11 @@
         "active": true,
         "type": "special",
         "id": "oneidact",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Passamaquoddy App. Ct.",
         "dates": [
             {
@@ -12936,11 +13414,11 @@
         "active": true,
         "type": "special",
         "id": "passamactapp",
-        "location": "Maine"
+        "location": "Maine",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Puyallup Tribal Ct. of App.",
         "dates": [
             {
@@ -12960,11 +13438,11 @@
         "active": true,
         "type": "special",
         "id": "puyallupctapp",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Puyallup Tribal Ct.",
         "dates": [
             {
@@ -12983,11 +13461,11 @@
         "court_url": "http://www.puyallup-tribe.com/court/",
         "type": "special",
         "id": "puyallupct",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Saint Regis Mohawk Tribal Ct.",
         "dates": [
             {
@@ -13007,11 +13485,11 @@
         "active": true,
         "type": "special",
         "id": "strmohawkct",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Confederated Salish & Kootenai Ct. of App.",
         "dates": [
             {
@@ -13031,11 +13509,11 @@
         "active": true,
         "type": "special",
         "id": "salishctapp",
-        "location": "Montana"
+        "location": "Montana",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Tulalip Ct. of App.",
         "dates": [
             {
@@ -13054,11 +13532,11 @@
         "active": true,
         "type": "special",
         "id": "tulalipctapp",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Tunica-Biloxi Tribal Ct.",
         "dates": [
             {
@@ -13077,11 +13555,11 @@
         "active": true,
         "type": "special",
         "id": "tunicabct",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "Turtle Mountain Tribal Ct. of App.",
         "dates": [
             {
@@ -13100,9 +13578,9 @@
         "active": true,
         "type": "special",
         "id": "turtlemtnctapp",
-        "location": "North Dakota"
+        "location": "North Dakota",
+        "citation_string": ""
     },
-
     {
         "regex": [
             "Delaware Court of Oyer and Terminer",
@@ -13126,7 +13604,8 @@
         "active": false,
         "type": "trial",
         "id": "deloyerterm",
-        "location": "Delaware"
+        "location": "Delaware",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13146,7 +13625,8 @@
         "examples": [],
         "type": "trial",
         "id": "hawlandct",
-        "location": "Hawaii"
+        "location": "Hawaii",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13169,9 +13649,10 @@
         "court_url": "http://www.dccourts.gov/internet/appellate/main.jsf",
         "type": "appellate",
         "id": "dc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "D.C."
     },
-  {
+    {
         "regex": [
             "${super} ${dc}",
             "Superior Court Of The District Of Columbia"
@@ -13187,16 +13668,17 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Superior Court Of The District Of Columbia",
-          "Superior Court Of The District Of Columbia Family Court",
-          "Superior Court Of The District Of Columbia Criminal Division",
-          "Superior Court Of The District Of Columbia Civil Division"
+            "Superior Court Of The District Of Columbia",
+            "Superior Court Of The District Of Columbia Family Court",
+            "Superior Court Of The District Of Columbia Criminal Division",
+            "Superior Court Of The District Of Columbia Civil Division"
         ],
         "type": "trial",
         "id": "dc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "D.C."
     },
-  {
+    {
         "regex": [
             "Supreme Court Of District Of Columbia"
         ],
@@ -13211,11 +13693,12 @@
         "case_types": [],
         "system": "state",
         "examples": [
-          "Supreme Court Of District Of Columbia"
+            "Supreme Court Of District Of Columbia"
         ],
         "type": "trial",
         "id": "dc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "D.C."
     },
     {
         "regex": [
@@ -13239,7 +13722,8 @@
         ],
         "type": "trial",
         "id": "njqrtsess",
-        "location": "New Jersey"
+        "location": "New Jersey",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13264,7 +13748,8 @@
         "court_url": "https://www.courts.wa.gov/appellate_trial_courts/?fa=atc.crtPage&crtType=Super",
         "type": "trial",
         "id": "washsuperct",
-        "location": "Washington"
+        "location": "Washington",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13283,7 +13768,8 @@
         "examples": [],
         "type": "appellate",
         "id": "bta",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13318,7 +13804,8 @@
         "court_url": "http://www.dcd.uscourts.gov/",
         "type": "appellate",
         "id": "dcd",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "D.C."
     },
     {
         "regex": [
@@ -13338,7 +13825,8 @@
         "court_url": "https://en.wikipedia.org/wiki/United_States_District_Court_for_the_District_of_Orleans",
         "type": "appellate",
         "id": "orld",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13359,7 +13847,8 @@
         "court_url": "http://www.fjc.gov/history/home.nsf/page/courts_special_com.html",
         "type": "appellate",
         "id": "com",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": "Comm. Ct."
     },
     {
         "regex": [
@@ -13389,9 +13878,10 @@
         "court_url": "http://www.vid.uscourts.gov/",
         "type": "trial",
         "id": "vid",
-        "location": "Virgin Islands"
+        "location": "Virgin Islands",
+        "citation_string": "D.V.I."
     },
-     {
+    {
         "regex": [
             "Municipal Court Of The Virgin Islands"
         ],
@@ -13409,7 +13899,8 @@
         "examples": [],
         "type": "trial",
         "id": "vimunict",
-        "location": "Virgin Islands"
+        "location": "Virgin Islands",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13429,7 +13920,8 @@
         "examples": [],
         "type": "trial",
         "id": "vipolct",
-        "location": "Virgin Islands"
+        "location": "Virgin Islands",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13449,7 +13941,8 @@
         "examples": [],
         "type": "trial",
         "id": "visuper",
-        "location": "Virgin Islands"
+        "location": "Virgin Islands",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13470,7 +13963,8 @@
         "examples": [],
         "type": "trial",
         "id": "virginislands",
-        "location": "Virgin Islands"
+        "location": "Virgin Islands",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -13500,7 +13994,8 @@
         "court_url": "http://www.fjc.gov/history/home.nsf/page/courts_special_coc.html",
         "type": "",
         "id": "cc",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": "Ct. Cl."
     },
     {
         "regex": [
@@ -13523,12 +14018,13 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States Patent And Trademark Office"
+            "United States Patent And Trademark Office"
         ],
         "court_url": "http://www.cafc.uscourts.gov/",
         "type": "appellate",
         "id": "ccpa",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": "C.C.P.A."
     },
     {
         "regex": [
@@ -13549,7 +14045,8 @@
         "court_url": "http://www.ustaxcourt.gov/",
         "type": "appellate",
         "id": "tax",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Tax Ct."
     },
     {
         "regex": [
@@ -13570,7 +14067,8 @@
         "court_url": "http://www.cit.uscourts.gov/",
         "type": "appellate",
         "id": "cit",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "Ct. Intl. Trade"
     },
     {
         "regex": [
@@ -13593,7 +14091,8 @@
         "court_url": "http://www.prd.uscourts.gov/",
         "type": "trial",
         "id": "prd",
-        "location": "Puerto Rico"
+        "location": "Puerto Rico",
+        "citation_string": "D.P.R."
     },
     {
         "regex": [
@@ -13618,7 +14117,8 @@
         "court_url": "https://en.wikipedia.org/wiki/United_States_District_Court_for_the_Canal_Zone",
         "type": "trial",
         "id": "canalzoned",
-        "location": "Panama"
+        "location": "Panama",
+        "citation_string": "D.C.Z."
     },
     {
         "regex": [
@@ -13642,7 +14142,8 @@
         "court_url": "http://www.fjc.gov/history/home.nsf/page/courts_special_cc_bib.html",
         "type": "appellate",
         "id": "cusc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Cust. Ct."
     },
     {
         "regex": [
@@ -13667,7 +14168,8 @@
         "court_url": "http://www.wyd.uscourts.gov/",
         "type": "trial",
         "id": "wyd",
-        "location": "Wyoming"
+        "location": "Wyoming",
+        "citation_string": "D. Wyo."
     },
     {
         "regex": [
@@ -13694,7 +14196,8 @@
         "court_url": "http://www.nmid.uscourts.gov/",
         "type": "trial",
         "id": "nmid",
-        "location": "Northern Mariana Islands"
+        "location": "Northern Mariana Islands",
+        "citation_string": "N. Mar. I."
     },
     {
         "regex": [
@@ -13731,7 +14234,8 @@
         "court_url": "http://www.ca9.uscourts.gov/",
         "type": "appellate",
         "id": "ca9",
-        "location": "California"
+        "location": "California",
+        "citation_string": "9th Cir."
     },
     {
         "regex": [
@@ -13762,7 +14266,8 @@
         "court_url": "http://www.ca8.uscourts.gov/",
         "type": "appellate",
         "id": "ca8",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "8th Cir."
     },
     {
         "regex": [
@@ -13798,7 +14303,8 @@
         "court_url": "http://www.ca3.uscourts.gov/",
         "type": "appellate",
         "id": "ca3",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": "3rd Cir."
     },
     {
         "regex": [
@@ -13833,7 +14339,8 @@
         "court_url": "http://www.ca2.uscourts.gov/",
         "type": "appellate",
         "id": "ca2",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": "2d Cir."
     },
     {
         "regex": [
@@ -13860,7 +14367,8 @@
         "court_url": "http://www.ca1.uscourts.gov/",
         "type": "appellate",
         "id": "ca1",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "1st Cir."
     },
     {
         "regex": [
@@ -13891,7 +14399,8 @@
         "court_url": "http://www.ca7.uscourts.gov/",
         "type": "appellate",
         "id": "ca7",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": "7th Cir."
     },
     {
         "regex": [
@@ -13919,7 +14428,8 @@
         "court_url": "http://www.ca6.uscourts.gov/",
         "type": "appellate",
         "id": "ca6",
-        "location": "Tennessee"
+        "location": "Tennessee",
+        "citation_string": "6th Cir."
     },
     {
         "regex": [
@@ -13958,7 +14468,8 @@
         "court_url": "http://www.ca5.uscourts.gov/",
         "type": "appellate",
         "id": "ca5",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": "5th Cir."
     },
     {
         "regex": [
@@ -13992,7 +14503,8 @@
         "court_url": "http://www.ca4.uscourts.gov/",
         "type": "appellate",
         "id": "ca4",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": "4th Cir."
     },
     {
         "regex": [
@@ -14029,7 +14541,8 @@
         "court_url": "http://www.cadc.uscourts.gov/",
         "type": "appellate",
         "id": "cadc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "D.C. Cir."
     },
     {
         "regex": [
@@ -14053,7 +14566,8 @@
         "court_url": "http://www.ca10.uscourts.gov/",
         "type": "appellate",
         "id": "ca10",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "10th Cir."
     },
     {
         "regex": [
@@ -14075,7 +14589,8 @@
         "court_url": "http://www.cafc.uscourts.gov/",
         "type": "appellate",
         "id": "cafc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Fed. Cir."
     },
     {
         "regex": [
@@ -14095,7 +14610,8 @@
         "court_url": "https://en.wikipedia.org/wiki/Court_of_King%27s_Bench_(England)",
         "type": "international",
         "id": "kingsbench",
-        "location": "England"
+        "location": "England",
+        "citation_string": "King's Bench"
     },
     {
         "regex": [
@@ -14115,7 +14631,8 @@
         "court_url": "",
         "type": "international",
         "id": "phillipines",
-        "location": "Phillipines"
+        "location": "Phillipines",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14136,7 +14653,8 @@
         "court_url": "http://www.dcb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "dcb",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Bankr. D.C."
     },
     {
         "regex": [
@@ -14158,7 +14676,8 @@
         "court_url": "http://www.vid.uscourts.gov/",
         "type": "bankruptcy",
         "id": "vib",
-        "location": "Virgin Islands"
+        "location": "Virgin Islands",
+        "citation_string": "Bankr. D.V.I."
     },
     {
         "regex": [
@@ -14179,7 +14698,8 @@
         "court_url": "http://www.prb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "prb",
-        "location": "Puerto Rico"
+        "location": "Puerto Rico",
+        "citation_string": "Bankr. D.P.R."
     },
     {
         "regex": [
@@ -14199,7 +14719,8 @@
         "court_url": "http://www.nmid.uscourts.gov/",
         "type": "bankruptcy",
         "id": "nmib",
-        "location": "Northern Mariana Islands"
+        "location": "Northern Mariana Islands",
+        "citation_string": "Bankr. N. Mar. I."
     },
     {
         "regex": [
@@ -14220,7 +14741,8 @@
         "court_url": "http://www.wyb.uscourts.gov/",
         "type": "bankruptcy",
         "id": "wyb",
-        "location": "Wyoming"
+        "location": "Wyoming",
+        "citation_string": "Bankr. D. Wyo."
     },
     {
         "regex": [
@@ -14240,7 +14762,8 @@
         "examples": [],
         "type": "special",
         "id": "usberlinct",
-        "location": "Berlin"
+        "location": "Berlin",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14260,7 +14783,8 @@
         "active": false,
         "type": "special",
         "id": "tecoa",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Temp. Emerg. Ct. App."
     },
     {
         "regex": [
@@ -14281,7 +14805,8 @@
         "active": false,
         "type": "special",
         "id": "eca",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Emer. Ct. App."
     },
     {
         "regex": [
@@ -14302,12 +14827,13 @@
         "notes": "See: https://en.wikipedia.org/wiki/Judicial_Panel_on_Multidistrict_Litigation",
         "system": "federal",
         "examples": [
-          "Before The Judicial Panel On Multidistrict Litigation"
+            "Before The Judicial Panel On Multidistrict Litigation"
         ],
         "active": true,
         "type": "special",
         "id": "jpml",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": "J.P.M.L."
     },
     {
         "regex": [
@@ -14330,7 +14856,8 @@
         "active": true,
         "type": "special",
         "id": "fisa",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14352,7 +14879,8 @@
         "active": true,
         "type": "special",
         "id": "uscfc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Fed. Cl."
     },
     {
         "regex": [
@@ -14373,9 +14901,9 @@
         "court_url": "",
         "type": "bankruptcy",
         "id": "bap1",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": "1st Cir. BAP"
     },
-
     {
         "regex": [
             "${usbap} ${n6} Circuit",
@@ -14392,15 +14920,15 @@
         "case_types": [],
         "system": "federal",
         "examples": [
-          "United States Bankruptcy Appellate Panel For The Sixth Circuit"
+            "United States Bankruptcy Appellate Panel For The Sixth Circuit"
         ],
         "active": true,
         "court_url": "",
         "type": "bankruptcy",
         "id": "bap6",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": "6th Cir. BAP"
     },
-
     {
         "regex": [
             "${usbap} ${n8} Circuit"
@@ -14420,7 +14948,8 @@
         "court_url": "",
         "type": "bankruptcy",
         "id": "bap8",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": "8th Cir. BAP"
     },
     {
         "regex": [
@@ -14444,7 +14973,8 @@
         "court_url": "",
         "type": "bankruptcy",
         "id": "bap9",
-        "location": "California"
+        "location": "California",
+        "citation_string": "9th Cir. BAP"
     },
     {
         "regex": [
@@ -14467,9 +14997,9 @@
         "court_url": "",
         "type": "bankruptcy",
         "id": "bap10",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": "10th Cir. BAP"
     },
-
     {
         "regex": [
             "United States Court of Veterans? Appeals",
@@ -14495,7 +15025,8 @@
         "court_url": "",
         "type": "special",
         "id": "cavc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "Vet. App."
     },
     {
         "regex": [
@@ -14519,7 +15050,8 @@
         "court_url": "",
         "type": "special",
         "id": "mc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "M.C."
     },
     {
         "regex": [
@@ -14548,7 +15080,8 @@
         "court_url": "",
         "type": "special",
         "id": "cma",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14577,7 +15110,8 @@
         "court_url": "",
         "type": "special",
         "id": "usnmcmilrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14600,7 +15134,8 @@
         "court_url": "",
         "type": "special",
         "id": "nmcca",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "N.M.C.C.A."
     },
     {
         "regex": [
@@ -14624,7 +15159,8 @@
         "court_url": "",
         "type": "special",
         "id": "armfor",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "C.A.A.F."
     },
     {
         "regex": [
@@ -14647,7 +15183,8 @@
         "court_url": "",
         "type": "special",
         "id": "cgcomilrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14670,7 +15207,8 @@
         "court_url": "",
         "type": "special",
         "id": "uscgbdrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14693,7 +15231,8 @@
         "court_url": "",
         "type": "special",
         "id": "usnbdrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14716,7 +15255,8 @@
         "court_url": "",
         "type": "special",
         "id": "usarmymilrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14739,7 +15279,8 @@
         "court_url": "",
         "type": "special",
         "id": "acca",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "A.C.C.A."
     },
     {
         "regex": [
@@ -14763,7 +15304,8 @@
         "notes": "https://en.wikipedia.org/wiki/Coast_Guard_Court_of_Criminal_Appeals",
         "type": "special",
         "id": "uscgcoca",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14786,7 +15328,8 @@
         "court_url": "",
         "type": "special",
         "id": "usarmybrdrev",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14809,7 +15352,8 @@
         "court_url": "",
         "type": "special",
         "id": "usafctmilrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14832,7 +15376,8 @@
         "court_url": "",
         "type": "special",
         "id": "afcca",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "A.F.C.C.A."
     },
     {
         "regex": [
@@ -14855,7 +15400,8 @@
         "court_url": "",
         "type": "special",
         "id": "usafbrdrev",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14878,9 +15424,9 @@
         "court_url": "",
         "type": "special",
         "id": "usjc",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": "U.S.J.C."
     },
-
     {
         "regex": [
             "Judicial Council Of The First Circuit"
@@ -14899,7 +15445,8 @@
         ],
         "type": "special",
         "id": "jc1",
-        "location": "Massachusetts"
+        "location": "Massachusetts",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14919,7 +15466,8 @@
         ],
         "type": "special",
         "id": "jc2",
-        "location": "New York"
+        "location": "New York",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14939,7 +15487,8 @@
         ],
         "type": "special",
         "id": "jc3",
-        "location": "Pennsylvania"
+        "location": "Pennsylvania",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14959,7 +15508,8 @@
         ],
         "type": "special",
         "id": "jc4",
-        "location": "Virginia"
+        "location": "Virginia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14979,7 +15529,8 @@
         ],
         "type": "special",
         "id": "jc5",
-        "location": "Louisiana"
+        "location": "Louisiana",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -14999,7 +15550,8 @@
         ],
         "type": "special",
         "id": "jc6",
-        "location": "Ohio"
+        "location": "Ohio",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15020,7 +15572,8 @@
         ],
         "type": "special",
         "id": "jc7",
-        "location": "Illinois"
+        "location": "Illinois",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15040,7 +15593,8 @@
         ],
         "type": "special",
         "id": "jc8",
-        "location": "Missouri"
+        "location": "Missouri",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15061,7 +15615,8 @@
         ],
         "type": "special",
         "id": "jc9",
-        "location": "California"
+        "location": "California",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15081,7 +15636,8 @@
         ],
         "type": "special",
         "id": "jc10",
-        "location": "Colorado"
+        "location": "Colorado",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15101,7 +15657,8 @@
         ],
         "type": "special",
         "id": "jc11",
-        "location": "Georgia"
+        "location": "Georgia",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15124,7 +15681,8 @@
         "court_url": "https://www.energy.gov/oha/decision-summaries",
         "type": "special",
         "id": "energyoha",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15148,7 +15706,8 @@
         "court_url": "https://oha.ed.gov/oha-judges-decisions/",
         "type": "special",
         "id": "educationoha",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15171,7 +15730,8 @@
         "court_url": "",
         "type": "special",
         "id": "maritimecomm",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15193,7 +15753,8 @@
         "court_url": "https://www.justice.gov/eoir/board-of-immigration-appeals",
         "type": "special",
         "id": "dojbia",
-        "location": "Washington D.C."
+        "location": "Washington D.C.",
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15217,11 +15778,12 @@
         ],
         "type": "special",
         "id": "reglrailreorgct",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": "Regl. Rail Reorg. Act"
     },
-      {
+    {
         "regex": [
-          "Circuit Court D Alabama"
+            "Circuit Court D Alabama"
         ],
         "name_abbreviation": "Ala. Cir. Ct",
         "dates": [
@@ -15238,12 +15800,13 @@
         "location": "Alabama",
         "type": "appellate",
         "id": "circtala",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Mid D Ala",
-          "Circuit Court ${md} ${al}"
+            "Circuit Court D Mid D Ala",
+            "Circuit Court ${md} ${al}"
         ],
         "name_abbreviation": "Mid. Ala. Cir. Ct",
         "dates": [
@@ -15260,7 +15823,8 @@
         "location": "Alabama",
         "type": "appellate",
         "id": "circtmidala",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15283,10 +15847,13 @@
         "location": "Alabama",
         "type": "appellate",
         "id": "circtnala",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court S D Ala"],
+        "regex": [
+            "Circuit Court S D Ala"
+        ],
         "name_abbreviation": "S. Ala. Cir. Ct",
         "dates": [
             {
@@ -15302,7 +15869,8 @@
         "location": "Alabama",
         "type": "appellate",
         "id": "circtsala",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15326,12 +15894,13 @@
         "location": "Arkansas",
         "type": "appellate",
         "id": "circtark",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court E D Ark",
-          "Circuit Court ${ed} ${ar}"
+            "Circuit Court E D Ark",
+            "Circuit Court ${ed} ${ar}"
         ],
         "name_abbreviation": "E. Ark. Cir. Ct",
         "dates": [
@@ -15348,12 +15917,13 @@
         "location": "Arkansas",
         "type": "appellate",
         "id": "circteark",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court W D Ark",
-          "Circuit Court ${wd} ${ar}"
+            "Circuit Court W D Ark",
+            "Circuit Court ${wd} ${ar}"
         ],
         "name_abbreviation": "W. Ark. Cir. Ct",
         "dates": [
@@ -15370,11 +15940,12 @@
         "location": "Arkansas",
         "type": "appellate",
         "id": "circtwark",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Terr D of Ark"
+            "Circuit Court D Terr D of Ark"
         ],
         "name_abbreviation": "Terr. of Ark. Cir. Ct",
         "dates": [
@@ -15391,12 +15962,13 @@
         "location": "Arkansas",
         "type": "appellate",
         "id": "circtterrofark",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Cal",
-          "Circuit Court ${d} ${ca}"
+            "Circuit Court D Cal",
+            "Circuit Court ${d} ${ca}"
         ],
         "name_abbreviation": "Cal. Cir. Ct",
         "dates": [
@@ -15413,12 +15985,13 @@
         "location": "California",
         "type": "appellate",
         "id": "caca",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court N D Cal",
-          "Circuit Court ${nd} ${ca}"
+            "Circuit Court N D Cal",
+            "Circuit Court ${nd} ${ca}"
         ],
         "name_abbreviation": "N. Cal. Cir. Ct",
         "dates": [
@@ -15435,10 +16008,13 @@
         "location": "California",
         "type": "appellate",
         "id": "circtncal",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court S D Cal"],
+        "regex": [
+            "Circuit Court S D Cal"
+        ],
         "name_abbreviation": "S. Cal. Cir. Ct",
         "dates": [
             {
@@ -15454,7 +16030,8 @@
         "location": "California",
         "type": "appellate",
         "id": "circtscal",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15476,11 +16053,12 @@
         "location": "South Carolina",
         "type": "appellate",
         "id": "circtscarolina",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Colorado"
+            "Circuit Court D Colorado"
         ],
         "name_abbreviation": "Colorado. Cir. Ct",
         "dates": [
@@ -15497,7 +16075,8 @@
         "location": "Colorado",
         "type": "appellate",
         "id": "circtcolorado",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15519,7 +16098,8 @@
         "location": "Washington D.C.",
         "type": "appellate",
         "id": "circtdc",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15543,10 +16123,13 @@
         "id": "circtconn",
         "examples": [
             "United States Circuit Court For The District Of Connecticut"
-        ]
+        ],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D North Dakota"],
+        "regex": [
+            "Circuit Court D North Dakota"
+        ],
         "name_abbreviation": "North Dakota. Cir. Ct",
         "dates": [
             {
@@ -15562,12 +16145,13 @@
         "location": "North Dakota",
         "type": "appellate",
         "id": "circtndakota",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D South Dakota",
-          "Circuit Court W D South Dakota"
+            "Circuit Court D South Dakota",
+            "Circuit Court W D South Dakota"
         ],
         "name_abbreviation": "South Dakota. Cir. Ct",
         "dates": [
@@ -15583,7 +16167,8 @@
         "location": "South Dakota",
         "type": "appellate",
         "id": "circtsdakota",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15610,11 +16195,12 @@
         "type": "appellate",
         "court_url": "http://www.fjc.gov/history/home.nsf/page/courts_circuit_de.html",
         "id": "circtdel",
-        "examples": []
+        "examples": [],
+        "citation_string": "Cir. Ct. Del."
     },
     {
         "regex": [
-          "Circuit Court N D Florida"
+            "Circuit Court N D Florida"
         ],
         "name_abbreviation": "N. Fla. Cir. Ct",
         "dates": [
@@ -15631,12 +16217,13 @@
         "location": "Florida",
         "type": "appellate",
         "id": "circtnfla",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court S D Fla",
-          "Circuit Court S D Florida"
+            "Circuit Court S D Fla",
+            "Circuit Court S D Florida"
         ],
         "name_abbreviation": "S. Fla. Cir. Ct",
         "dates": [
@@ -15653,11 +16240,12 @@
         "location": "Florida",
         "type": "appellate",
         "id": "circtsfla",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D ${ga}"
+            "Circuit Court D ${ga}"
         ],
         "name_abbreviation": "Ga. Cir. Ct",
         "dates": [
@@ -15674,10 +16262,13 @@
         "location": "Georgia",
         "type": "appellate",
         "id": "circtga",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court N D Ga"],
+        "regex": [
+            "Circuit Court N D Ga"
+        ],
         "name_abbreviation": "N. Ga. Cir. Ct",
         "dates": [
             {
@@ -15693,10 +16284,13 @@
         "location": "Georgia",
         "type": "appellate",
         "id": "circtnga",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court S D Ga"],
+        "regex": [
+            "Circuit Court S D Ga"
+        ],
         "name_abbreviation": "S. Ga. Cir. Ct",
         "dates": [
             {
@@ -15712,10 +16306,13 @@
         "location": "Georgia",
         "type": "appellate",
         "id": "circtsga",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D New Hampshire"],
+        "regex": [
+            "Circuit Court D New Hampshire"
+        ],
         "name_abbreviation": "New Hampshire. Cir. Ct",
         "dates": [
             {
@@ -15731,7 +16328,8 @@
         "location": "New Hampshire",
         "type": "appellate",
         "id": "circtnh",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15753,10 +16351,13 @@
         "location": "Idaho",
         "type": "appellate",
         "id": "circtidaho",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Ill"],
+        "regex": [
+            "Circuit Court D Ill"
+        ],
         "name_abbreviation": "Ill. Cir. Ct",
         "dates": [
             {
@@ -15772,7 +16373,8 @@
         "location": "Illinois",
         "type": "appellate",
         "id": "circtill",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15794,10 +16396,13 @@
         "location": "Illinois",
         "type": "appellate",
         "id": "circteill",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court N D Ill"],
+        "regex": [
+            "Circuit Court N D Ill"
+        ],
         "name_abbreviation": "N. Ill. Cir. Ct",
         "dates": [
             {
@@ -15813,11 +16418,12 @@
         "location": "Illinois",
         "type": "appellate",
         "id": "circtnill",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court S D Illinois"
+            "Circuit Court S D Illinois"
         ],
         "name_abbreviation": "S. Ill. Cir. Ct",
         "dates": [
@@ -15834,11 +16440,12 @@
         "location": "Illinois",
         "type": "appellate",
         "id": "circtsill",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Indiana"
+            "Circuit Court D Indiana"
         ],
         "name_abbreviation": "Indiana. Cir. Ct",
         "dates": [
@@ -15855,7 +16462,8 @@
         "location": "Indiana",
         "type": "appellate",
         "id": "circtindiana",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15879,12 +16487,13 @@
         "type": "appellate",
         "id": "circtniowa",
         "examples": [
-          "Circuit Court C D Iowa N D"
-        ]
+            "Circuit Court C D Iowa N D"
+        ],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court S D Iowa"
+            "Circuit Court S D Iowa"
         ],
         "name_abbreviation": "S. Iowa Cir. Ct",
         "dates": [
@@ -15901,11 +16510,12 @@
         "location": "Iowa",
         "type": "appellate",
         "id": "circtsiowa",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Iowa"
+            "Circuit Court D Iowa"
         ],
         "name_abbreviation": "Iowa. Cir. Ct",
         "dates": [
@@ -15922,12 +16532,13 @@
         "location": "Iowa",
         "type": "appellate",
         "id": "circtiowa",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Rhodes? Island",
-          "Circuit Court Rhode Island"
+            "Circuit Court D Rhodes? Island",
+            "Circuit Court Rhode Island"
         ],
         "name_abbreviation": "Rhode Island. Cir. Ct",
         "dates": [
@@ -15944,7 +16555,8 @@
         "location": "Rhode Island",
         "type": "appellate",
         "id": "circtri",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15966,7 +16578,8 @@
         "location": "New Jersey",
         "type": "appellate",
         "id": "circtnewjersey",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -15990,11 +16603,14 @@
         "type": "appellate",
         "id": "circtkansas",
         "examples": [
-          "Circuit Court Kansas First Division"
-        ]
+            "Circuit Court Kansas First Division"
+        ],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court E D Ky"],
+        "regex": [
+            "Circuit Court E D Ky"
+        ],
         "name_abbreviation": "E. Ky. Cir. Ct",
         "dates": [
             {
@@ -16010,10 +16626,13 @@
         "location": "Kentucky",
         "type": "appellate",
         "id": "circteky",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Ky"],
+        "regex": [
+            "Circuit Court D Ky"
+        ],
         "name_abbreviation": "Ky. Cir. Ct",
         "dates": [
             {
@@ -16029,10 +16648,13 @@
         "location": "Kentucky",
         "type": "appellate",
         "id": "circtky",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court W D Ky"],
+        "regex": [
+            "Circuit Court W D Ky"
+        ],
         "name_abbreviation": "W. Ky. Cir. Ct",
         "dates": [
             {
@@ -16048,10 +16670,13 @@
         "location": "Kentucky",
         "type": "appellate",
         "id": "circtwky",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court E D La"],
+        "regex": [
+            "Circuit Court E D La"
+        ],
         "name_abbreviation": "E. La. Cir. Ct",
         "dates": [
             {
@@ -16067,7 +16692,8 @@
         "location": "Louisiana",
         "type": "appellate",
         "id": "circtela",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16089,10 +16715,13 @@
         "location": "Louisiana",
         "type": "appellate",
         "id": "circtla",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court W D La"],
+        "regex": [
+            "Circuit Court W D La"
+        ],
         "name_abbreviation": "W. La. Cir. Ct",
         "dates": [
             {
@@ -16108,10 +16737,13 @@
         "location": "Louisiana",
         "type": "appellate",
         "id": "circtwla",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Maine"],
+        "regex": [
+            "Circuit Court D Maine"
+        ],
         "name_abbreviation": "Maine. Cir. Ct",
         "dates": [
             {
@@ -16127,7 +16759,8 @@
         "location": "Maine",
         "type": "appellate",
         "id": "circtmaine",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16150,7 +16783,8 @@
         "location": "Maryland",
         "type": "appellate",
         "id": "circtmaryland",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16175,11 +16809,12 @@
         "id": "circtmass",
         "examples": [
             "Circuit Court Of U S Massachusetts District Equity Term"
-        ]
+        ],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court E D Michigan"
+            "Circuit Court E D Michigan"
         ],
         "name_abbreviation": "E. Mich. Cir. Ct",
         "dates": [
@@ -16196,12 +16831,13 @@
         "location": "Michigan",
         "type": "appellate",
         "id": "circtemich",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court W D Michigan",
-          "Circuit Court S D Michigan W D"
+            "Circuit Court W D Michigan",
+            "Circuit Court S D Michigan W D"
         ],
         "name_abbreviation": "W. Mich. Cir. Ct",
         "dates": [
@@ -16218,11 +16854,12 @@
         "location": "Michigan",
         "type": "appellate",
         "id": "circtwmich",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
-          "Circuit Court D Michigan"
+            "Circuit Court D Michigan"
         ],
         "name_abbreviation": "Mich. Cir. Ct",
         "dates": [
@@ -16239,10 +16876,13 @@
         "location": "Michigan",
         "type": "appellate",
         "id": "circtmich",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Minnesota"],
+        "regex": [
+            "Circuit Court D Minnesota"
+        ],
         "name_abbreviation": "Minnesota. Cir. Ct",
         "dates": [
             {
@@ -16258,11 +16898,12 @@
         "location": "Minnesota",
         "type": "appellate",
         "id": "circtminnesota",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court N D Miss"
+            "Circuit Court N D Miss"
         ],
         "name_abbreviation": "N. Miss. Cir. Ct",
         "dates": [
@@ -16279,10 +16920,13 @@
         "location": "Mississippi",
         "type": "appellate",
         "id": "circtnmiss",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court S D Miss"],
+        "regex": [
+            "Circuit Court S D Miss"
+        ],
         "name_abbreviation": "S. Miss. Cir. Ct",
         "dates": [
             {
@@ -16298,7 +16942,8 @@
         "location": "Mississippi",
         "type": "appellate",
         "id": "circtsmiss",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16321,10 +16966,13 @@
         "location": "Missouri",
         "type": "appellate",
         "id": "circtemo",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Mo"],
+        "regex": [
+            "Circuit Court D Mo"
+        ],
         "name_abbreviation": "Mo. Cir. Ct",
         "dates": [
             {
@@ -16340,7 +16988,8 @@
         "location": "Missouri",
         "type": "appellate",
         "id": "circtmo",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16362,10 +17011,13 @@
         "location": "Missouri",
         "type": "appellate",
         "id": "circtwmo",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Montana"],
+        "regex": [
+            "Circuit Court D Montana"
+        ],
         "name_abbreviation": "Montana. Cir. Ct",
         "dates": [
             {
@@ -16381,10 +17033,13 @@
         "location": "Montana",
         "type": "appellate",
         "id": "circtmontana",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court E D N.C"],
+        "regex": [
+            "Circuit Court E D N.C"
+        ],
         "name_abbreviation": "E. N.C. Cir. Ct",
         "dates": [
             {
@@ -16400,7 +17055,8 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtenc",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16422,11 +17078,12 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtnc",
-        "examples": []
+        "examples": [],
+        "citation_string": "Cir. Ct. N.C."
     },
     {
         "regex": [
-          "Circuit Court D Cape Fear North Carolina"
+            "Circuit Court D Cape Fear North Carolina"
         ],
         "dates": [
             {
@@ -16442,12 +17099,12 @@
         "type": "appellate",
         "id": "circtcapefearnc",
         "examples": [
-          "Circuit Court D Cape Fear North Carolina"
-        ]
-    },
-      {
-        "regex": [
+            "Circuit Court D Cape Fear North Carolina"
         ],
+        "citation_string": ""
+    },
+    {
+        "regex": [],
         "name_abbreviation": "",
         "dates": [
             {
@@ -16462,11 +17119,11 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtedentonnc",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "",
         "dates": [
             {
@@ -16481,11 +17138,11 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtnewbernnc",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "",
         "dates": [
             {
@@ -16500,12 +17157,11 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtwilmington",
-        "examples": [
-        ]
+        "examples": [],
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "",
         "dates": [
             {
@@ -16520,11 +17176,11 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtalbermarle",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
-  {
-        "regex": [
-        ],
+    {
+        "regex": [],
         "name_abbreviation": "",
         "dates": [
             {
@@ -16539,12 +17195,12 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtpampticonc",
-        "examples": [
-        ]
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court W D N.C"
+            "Circuit Court W D N.C"
         ],
         "name_abbreviation": "W. N.C. Cir. Ct",
         "dates": [
@@ -16561,7 +17217,8 @@
         "location": "North Carolina",
         "type": "appellate",
         "id": "circtwnc",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16584,10 +17241,13 @@
         "location": "Nebraska",
         "type": "appellate",
         "id": "circtnebraska",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Nevada"],
+        "regex": [
+            "Circuit Court D Nevada"
+        ],
         "name_abbreviation": "Nevada. Cir. Ct",
         "dates": [
             {
@@ -16603,10 +17263,13 @@
         "location": "Nevada",
         "type": "appellate",
         "id": "circtnevada",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court N D Ohi"],
+        "regex": [
+            "Circuit Court N D Ohi"
+        ],
         "name_abbreviation": "N. Ohio Cir. Ct",
         "dates": [
             {
@@ -16622,7 +17285,8 @@
         "location": "Ohio",
         "type": "appellate",
         "id": "circtnohio",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16644,7 +17308,8 @@
         "location": "Ohio",
         "type": "appellate",
         "id": "circtsohio",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16668,11 +17333,14 @@
         "type": "appellate",
         "id": "circtohio",
         "examples": [
-          "State Of Ohio U S Circuit Court"
-        ]
+            "State Of Ohio U S Circuit Court"
+        ],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court E D Okla"],
+        "regex": [
+            "Circuit Court E D Okla"
+        ],
         "name_abbreviation": "E. Okla. Cir. Ct",
         "dates": [
             {
@@ -16688,12 +17356,13 @@
         "location": "Oklahoma",
         "type": "appellate",
         "id": "circteokla",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court W D Okla",
-          "Circuit Court W D Oklahoma"
+            "Circuit Court W D Okla",
+            "Circuit Court W D Oklahoma"
         ],
         "name_abbreviation": "W. Okla. Cir. Ct",
         "dates": [
@@ -16710,12 +17379,13 @@
         "location": "Oklahoma",
         "type": "appellate",
         "id": "circtwokla",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Oregon",
-          "Circuit Court District Of Oregon"
+            "Circuit Court D Oregon",
+            "Circuit Court District Of Oregon"
         ],
         "name_abbreviation": "Oregon. Cir. Ct",
         "dates": [
@@ -16732,11 +17402,12 @@
         "location": "Oregon",
         "type": "appellate",
         "id": "circtoregon",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court ${ed} ${pa}"
+            "Circuit Court ${ed} ${pa}"
         ],
         "name_abbreviation": "E. Pa. Cir. Ct",
         "dates": [
@@ -16753,10 +17424,13 @@
         "location": "Pennsylvania",
         "type": "appellate",
         "id": "circtepa",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Mid D Pa"],
+        "regex": [
+            "Circuit Court D Mid D Pa"
+        ],
         "name_abbreviation": "Mid. Pa. Cir. Ct",
         "dates": [
             {
@@ -16772,7 +17446,8 @@
         "location": "Pennsylvania",
         "type": "appellate",
         "id": "circtmidpa",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16797,11 +17472,14 @@
         "type": "appellate",
         "id": "circtpa",
         "examples": [
-          "Circuit Court D Pennsylvania"
-        ]
+            "Circuit Court D Pennsylvania"
+        ],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court W D Pennsylvania"],
+        "regex": [
+            "Circuit Court W D Pennsylvania"
+        ],
         "name_abbreviation": "W. Pa. Cir. Ct",
         "dates": [
             {
@@ -16817,7 +17495,8 @@
         "location": "Pennsylvania",
         "type": "appellate",
         "id": "circtwpa",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16840,7 +17519,8 @@
         "location": "Tennessee",
         "type": "appellate",
         "id": "circtetenn",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16862,7 +17542,8 @@
         "location": "Tennessee",
         "type": "appellate",
         "id": "circtmtenn",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16884,10 +17565,13 @@
         "location": "Tennessee",
         "type": "appellate",
         "id": "circttenn",
-        "examples": []
+        "examples": [],
+        "citation_string": "Cir. Ct. N.C."
     },
     {
-        "regex": ["Circuit Court W D Tenn"],
+        "regex": [
+            "Circuit Court W D Tenn"
+        ],
         "name_abbreviation": "W. Tenn. Cir. Ct",
         "dates": [
             {
@@ -16903,9 +17587,10 @@
         "location": "Tennessee",
         "type": "appellate",
         "id": "circtwtenn",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
-   {
+    {
         "regex": [
             "Circuit Court D Texas"
         ],
@@ -16926,7 +17611,8 @@
         "id": "circtetex",
         "examples": [
             "Circuit Court D Texas"
-        ]
+        ],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -16948,10 +17634,13 @@
         "location": "Texas",
         "type": "appellate",
         "id": "circtetex",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court N D Tex"],
+        "regex": [
+            "Circuit Court N D Tex"
+        ],
         "name_abbreviation": "N. Tex. Cir. Ct",
         "dates": [
             {
@@ -16967,10 +17656,13 @@
         "location": "Texas",
         "type": "appellate",
         "id": "circtntex",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court S D Tex"],
+        "regex": [
+            "Circuit Court S D Tex"
+        ],
         "name_abbreviation": "S. Tex. Cir. Ct",
         "dates": [
             {
@@ -16986,10 +17678,13 @@
         "location": "Texas",
         "type": "appellate",
         "id": "circtstex",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court W D Tex"],
+        "regex": [
+            "Circuit Court W D Tex"
+        ],
         "name_abbreviation": "W. Tex. Cir. Ct",
         "dates": [
             {
@@ -17005,10 +17700,13 @@
         "location": "Texas",
         "type": "appellate",
         "id": "circtwtex",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Utah"],
+        "regex": [
+            "Circuit Court D Utah"
+        ],
         "name_abbreviation": "Utah. Cir. Ct",
         "dates": [
             {
@@ -17024,7 +17722,8 @@
         "location": "Utah",
         "type": "appellate",
         "id": "circtutah",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17047,10 +17746,13 @@
         "location": "Virginia",
         "type": "appellate",
         "id": "circtva",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court E D Va"],
+        "regex": [
+            "Circuit Court E D Va"
+        ],
         "name_abbreviation": "E. Va. Cir. Ct",
         "dates": [
             {
@@ -17066,7 +17768,8 @@
         "location": "Virginia",
         "type": "appellate",
         "id": "circteva",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17088,10 +17791,13 @@
         "location": "Virginia",
         "type": "appellate",
         "id": "circtwva",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court N D West Va"],
+        "regex": [
+            "Circuit Court N D West Va"
+        ],
         "name_abbreviation": "N. West Va. Cir. Ct",
         "dates": [
             {
@@ -17107,10 +17813,13 @@
         "location": "West Virginia",
         "type": "appellate",
         "id": "circtnwestva",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court S D West Va"],
+        "regex": [
+            "Circuit Court S D West Va"
+        ],
         "name_abbreviation": "S. West Va. Cir. Ct",
         "dates": [
             {
@@ -17126,10 +17835,13 @@
         "location": "West Virginia",
         "type": "appellate",
         "id": "circtswestva",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D West Va"],
+        "regex": [
+            "Circuit Court D West Va"
+        ],
         "name_abbreviation": "West Va. Cir. Ct",
         "dates": [
             {
@@ -17145,10 +17857,13 @@
         "location": "West Virginia",
         "type": "appellate",
         "id": "circtwestva",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Vermont"],
+        "regex": [
+            "Circuit Court D Vermont"
+        ],
         "name_abbreviation": "Vermont. Cir. Ct",
         "dates": [
             {
@@ -17164,7 +17879,8 @@
         "location": "Vermont",
         "type": "appellate",
         "id": "circtvermont",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17186,10 +17902,13 @@
         "location": "Washington",
         "type": "appellate",
         "id": "circtewash",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
-        "regex": ["Circuit Court D Wash"],
+        "regex": [
+            "Circuit Court D Wash"
+        ],
         "name_abbreviation": "Wash. Cir. Ct",
         "dates": [
             {
@@ -17205,7 +17924,8 @@
         "location": "Washington",
         "type": "appellate",
         "id": "circtwash",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17226,11 +17946,12 @@
         "location": "Washington",
         "type": "appellate",
         "id": "circtwwash",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court ${ed} ${wi}"
+            "Circuit Court ${ed} ${wi}"
         ],
         "name_abbreviation": "E. Wis. Cir. Ct",
         "dates": [
@@ -17246,8 +17967,9 @@
         "system": "federal",
         "location": "Wisconsin",
         "type": "appellate",
-            "id": "circtewis",
-        "examples": []
+        "id": "circtewis",
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17269,12 +17991,13 @@
         "location": "Wisconsin",
         "type": "appellate",
         "id": "circtwwis",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D ${wi}",
-          "Circuit Court ${wi}"
+            "Circuit Court D ${wi}",
+            "Circuit Court ${wi}"
         ],
         "name_abbreviation": "Wis. Cir. Ct",
         "dates": [
@@ -17291,12 +18014,13 @@
         "location": "Wisconsin",
         "type": "appellate",
         "id": "circtwis",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
-          "Circuit Court D Wyoming",
-          "Circuit Court ${wy}"
+            "Circuit Court D Wyoming",
+            "Circuit Court ${wy}"
         ],
         "name_abbreviation": "Wyoming. Cir. Ct",
         "dates": [
@@ -17313,7 +18037,8 @@
         "location": "Wyoming",
         "type": "appellate",
         "id": "circtwyoming",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17335,7 +18060,8 @@
         "location": "New York",
         "type": "appellate",
         "id": "circtalbanyny",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17357,7 +18083,8 @@
         "location": "New York",
         "type": "appellate",
         "id": "circteasternny",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17380,7 +18107,8 @@
         "location": "New York",
         "type": "appellate",
         "id": "circtnorthernny",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17404,7 +18132,8 @@
         "location": "New York",
         "type": "appellate",
         "id": "circtsouthernny",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
     {
         "regex": [
@@ -17426,9 +18155,10 @@
         "location": "New York",
         "type": "appellate",
         "id": "circtwesternny",
-        "examples": []
+        "examples": [],
+        "citation_string": ""
     },
-  {
+    {
         "regex": [
             "Federal Communications Commission"
         ],
@@ -17452,50 +18182,53 @@
         "system": "federal",
         "type": "special",
         "id": "fcc",
-        "location": "Washignton D.C."
+        "location": "Washignton D.C.",
+        "citation_string": ""
     },
-      {
-      "regex": [
-          "Court Of Appeals Of Indian Territory"
-      ],
-      "dates": [
-        {
-          "start": "1889-01-01",
-          "end": "1907-12-31"
-        }
-      ],
-      "name": "Court Of Appeals Of Indian Territory",
-      "level": "gjc",
-      "case_types": [],
-      "system": "special",
-      "examples": [
-          "Court Of Appeals Of Indian Territory"
-      ],
-      "court_url": "",
-      "type": "appellate",
-      "id": "cait",
-      "location": "Washinton D.C."
+    {
+        "regex": [
+            "Court Of Appeals Of Indian Territory"
+        ],
+        "dates": [
+            {
+                "start": "1889-01-01",
+                "end": "1907-12-31"
+            }
+        ],
+        "name": "Court Of Appeals Of Indian Territory",
+        "level": "gjc",
+        "case_types": [],
+        "system": "special",
+        "examples": [
+            "Court Of Appeals Of Indian Territory"
+        ],
+        "court_url": "",
+        "type": "appellate",
+        "id": "cait",
+        "location": "Washinton D.C.",
+        "citation_string": ""
     },
-  {
-      "regex": [
-          "State Of California Commission On Judicial Performance"
-      ],
-      "dates": [
-        {
-          "start": null,
-          "end": null
-        }
-      ],
-      "name": "State Of California Commission On Judicial Performance",
-      "level": "ljc",
-      "case_types": [],
-      "system": "special",
-      "examples": [
-          "State Of California Commission On Judicial Performance"
-      ],
-      "court_url": "",
-      "type": "trial",
-      "id": "caljp",
-      "location": "California"
+    {
+        "regex": [
+            "State Of California Commission On Judicial Performance"
+        ],
+        "dates": [
+            {
+                "start": null,
+                "end": null
+            }
+        ],
+        "name": "State Of California Commission On Judicial Performance",
+        "level": "ljc",
+        "case_types": [],
+        "system": "special",
+        "examples": [
+            "State Of California Commission On Judicial Performance"
+        ],
+        "court_url": "",
+        "type": "trial",
+        "id": "caljp",
+        "location": "California",
+        "citation_string": ""
     }
 ]


### PR DESCRIPTION
Pursuant to the discussion at https://github.com/freelawproject/courtlistener/issues/1521#issuecomment-753671869 et seq., this PR takes the citation_string data that is currently stored on `Court` objects in the CL's database and adds it to this centralized `courts_db` repo.

The code that I used to do the merge is here, if you want to make sure it's not insane: https://gist.github.com/mattdahl/1b786674ca7ef37a02ba748675ae2d57

The diff is pretty clean, except for two things. First, there are a couple of indentation changes, but this is because the existing indentation was off for a couple of the JSON objects (my changes standardize the indentation). Second, my changes remove a handful of `\u200e` entities that were appended to some of the court URLs. This happened automatically when I ran `JSON.stringify()`, but I don't see why they would be there in the first place, so I see no harm in removing them.