### PR TITLE
Specify encoding when opening files

### DIFF
--- a/courts_db/utils.py
+++ b/courts_db/utils.py
@@ -3,7 +3,7 @@ import os
 import re
 from glob import iglob
 from io import open
-from string import Template, punctuation
+from string import Template
 
 db_root = os.path.dirname(os.path.realpath(__file__))
 
@@ -133,24 +133,30 @@ def load_courts_db():
 
     :return: A python object containing the rendered courts DB
     """
-    with open(os.path.join(db_root, "data", "variables.json"), "r") as v:
+    with open(
+        os.path.join(db_root, "data", "variables.json"), "r", encoding="utf-8"
+    ) as v:
         variables = json.load(v)
 
     for path in iglob(os.path.join(db_root, "data", "places", "*.txt")):
-        with open(path, "r") as p:
+        with open(path, "r", encoding="utf-8") as p:
             places = f"({'|'.join(p.read().splitlines())})"
             variables[path.split(os.path.sep)[-1].split(".txt")[0]] = places
 
     # Add in code to allow ordinal creation for many many judicial district numbers
     # for example 1 to 56 judicial districts
-    with open(os.path.join(db_root, "data", "courts.json"), "r") as f:
+    with open(
+        os.path.join(db_root, "data", "courts.json"), "r", encoding="utf-8"
+    ) as f:
         temp = f.read()
         ord_arrays = re.findall(r"\${(\d+)-(\d+)}", temp)
         for ord in ord_arrays:
             re_ord = f"(({')|('.join(ordinals[int(ord[0])-1: int(ord[1])])}))"
             temp = temp.replace(f"${{{ord[0]}-{ord[1]}}}", re_ord)
 
-    with open(os.path.join(db_root, "data", "courts.json"), "r") as f:
+    with open(
+        os.path.join(db_root, "data", "courts.json"), "r", encoding="utf-8"
+    ) as f:
         s = Template(temp).substitute(**variables)
     s = s.replace("\\", "\\\\")
     data = json.loads(s)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(*parts):
     Build an absolute path from *parts* and and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
-    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+    with codecs.open(os.path.join(HERE, *parts), "rb", encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests.py
+++ b/tests.py
@@ -155,7 +155,11 @@ class JsonTest(CourtsDBTestCase):
         """Does our json load properly, and if not where are the issues"""
         try:
             # Load entire json to shortcircuit testing
-            with open(os.path.join(db_root, "data", "courts.json"), "r") as f:
+            with open(
+                os.path.join(db_root, "data", "courts.json"),
+                "r",
+                encoding="utf-8",
+            ) as f:
                 data = f.read()
                 json.loads(data)
                 return


### PR DESCRIPTION
This change specifies encoding to utf-8 to ensure cross-platform compatibility when opening files in text mode.  This change specifies the encoding to utf-8 to ensure cross-platform compatibility when opening files in text mode. In this case when loading the json files for courts, variables, states, places, etc.

With this change, Windows users will have no problem when running tests due to court accents (specifically for puerto rico).
