### PR TITLE
Issue 53 - Adds support for 2d and 3d circuit numerals

### DIFF
--- a/courts_db/data/variables.json
+++ b/courts_db/data/variables.json
@@ -86,8 +86,8 @@
     "supct": "Sup(reme)? C(our)?t",
 
     "n1": "(First|One|1st|1)",
-    "n2": "(Second|Two|2nd|2)",
-    "n3": "(Third|Three|3rd|3)",
+    "n2": "(Second|Two|2nd|2d|2)",
+    "n3": "(Third|Three|3rd|3d|3)",
     "n4": "(Fou?rth|Four|4th|4)",
     "n5": "(Fifth|Five|5th|5)",
     "n6": "(Sixth|Six|6th|6)",


### PR DESCRIPTION
As mentioned in #53, we don't currently recognize "2d Cir." and "3d Cir." court strings, despite these being the standard Bluebook format! I was quite surprised to encounter this. E.g.:

```
get_citations('PWS Holding Corp., 228 F.3d 224 (3d Cir. 2000)')
```

returns: [FullCaseCitation('228 F.3d 224', groups={'volume': '228', 'reporter': 'F.3d', 'page': '224'}, metadata=FullCaseCitation.Metadata(parenthetical=None, pin_cite=None, pin_cite_span_start=None, pin_cite_span_end=None, year='2000', **court=None**, plaintiff=None, defendant=None, extra=None, antecedent_guess='Corp.', resolved_case_name_short=None, resolved_case_name=None))]

This PR is a simple addition to our regexes to handle these formats.