### PR TITLE
fix(ci): Separate concurrency groups by workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
e0d59cac64e224835b84bc56e62ef3fb7f7dfbd9 had a flaw: it cancelled in-progress runs *between* workflows, meaning that the tests running could cancel the linting workflow, and vice versa.

This could actually be seen on the PR, as [the lint run](https://github.com/freelawproject/courts-db/actions/runs/14939285165) cancelled itself.

This PR corrects the mistake.