### PR TITLE
fix: Resolve broken code by loading courts data correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 - Add workflow to check for new entries in CHANGES.md file
 - Adds support for "2d Cir." and "3d Cir." court strings
 - Support Python 3.13
+- Fix Broken code in find_court_ids_by_name #106
+
 
 ## Current Version
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - Add workflow to check for new entries in CHANGES.md file
 - Adds support for "2d Cir." and "3d Cir." court strings
 - Support Python 3.13
-- Change noqa F821  message #106
+- Change noqa F821  message  from "This code is broken." to "courts is imported lazily via __getattr__" #106
 
 
 ## Current Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - Add workflow to check for new entries in CHANGES.md file
 - Adds support for "2d Cir." and "3d Cir." court strings
 - Support Python 3.13
-- Fix Broken code in find_court_ids_by_name #106
+- Change noqa F821  message #106
 
 
 ## Current Version

--- a/courts_db/__init__.py
+++ b/courts_db/__init__.py
@@ -87,8 +87,7 @@ def find_court_ids_by_name(
 
     # If no matches found - check against - Court Name - not regex patterns.
     if not matches:
-        courts_data = globals().get("courts", load_courts_db())
-        for court in courts_data:
+        for court in courts:  # noqa: F821  courts is imported lazily via __getattr__
             # Add validation for location if provided.
             if location and court_location != location:
                 continue

--- a/courts_db/__init__.py
+++ b/courts_db/__init__.py
@@ -87,7 +87,8 @@ def find_court_ids_by_name(
 
     # If no matches found - check against - Court Name - not regex patterns.
     if not matches:
-        for court in courts:  # noqa: F821  This code is broken.
+        courts_data = globals().get("courts", load_courts_db())
+        for court in courts_data:
             # Add validation for location if provided.
             if location and court_location != location:
                 continue


### PR DESCRIPTION
This pull request fixes a broken code section in the `find_court_ids_by_name` function within `courts_db/__init__.py`. The change ensures that the `courts` variable is properly initialized using `globals()` or by loading the courts database.

Fix for broken code:

* [`courts_db/__init__.py`](diffhunk://#diff-84c9a8db7393b16e47b6539805055a87d95b538fc4813d9a29fe7933b8cfb676L90-R91): Updated the `find_court_ids_by_name` function to replace the undefined `courts` variable with `courts_data`, which is initialized using `globals().get("courts", load_courts_db())`. This resolves the issue where the code was broken due to an undefined variable.