### PR TITLE
fix: Remove the license-files field from the [project] section. The l…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ description = "Database of Courts"
 readme = "README.rst"
 keywords = [ "courts", "legal" ]
 license = "BSD-2-Clause"
-license-files = [ "LICENSE" ]
 authors = [
   { name = "Free Law Project", email = "info@free.law" },
 ]


### PR DESCRIPTION
…icense-files field is not part of the PEP 621 standard and should not be in the [project] section