### PR TITLE
Add California State Bar Court

### DIFF
--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -2542,6 +2542,37 @@
         "type": "trial"
     },
     {
+        "citation_string": "Cal. State Bar Ct.",
+        "court_url": "https://www.statebarcourt.ca.gov/",
+        "dates": [
+            {
+                "end": null,
+                "start": "1989-01-01"
+            }
+        ],
+        "examples": [
+            "State Bar Court of California",
+            "California State Bar Court",
+            "State Bar Court Review Department",
+            "State Bar Court Hearing Department"
+        ],
+        "id": "calstatebar",
+        "level": "special",
+        "location": "California",
+        "name": "State Bar Court of California",
+        "name_abbreviation": "Cal. State Bar Ct.",
+        "notes": "Disciplinary tribunal for California attorneys. Has Hearing Department (5 judges) and Review Department (3 judges). Final appeals go to California Supreme Court.",
+        "regex": [
+            "State Bar Court of California",
+            "California State Bar Court",
+            "State Bar Court",
+            "Cal\\.? State Bar Court",
+            "State Bar of California Court"
+        ],
+        "system": "state",
+        "type": "special"
+    },
+    {
         "active": true,
         "case_types": [],
         "citation_string": "9th Cir. BAP",

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -2570,7 +2570,7 @@
             "State Bar of California Court"
         ],
         "system": "state",
-        "type": "special"
+        "type": "ljc"
     },
     {
         "active": true,


### PR DESCRIPTION
## Summary

Adds the State Bar Court of California (`calstatebar`) to the courts database.

## Details

The State Bar Court of California is a special tribunal that handles attorney discipline matters. It consists of:
- **Hearing Department**: 5 judges who conduct initial hearings
- **Review Department**: 3 judges who hear appeals from the Hearing Department

Final appeals from the State Bar Court go to the California Supreme Court.

## New Entry

- **ID**: `calstatebar`
- **Name**: State Bar Court of California
- **Citation**: Cal. State Bar Ct.
- **URL**: https://www.statebarcourt.ca.gov/
- **Type**: special
- **System**: state
- **Location**: California

## Testing

- All existing tests pass
- New court can be found by ID and string matching

## Related

Fixes #119

This PR addresses one of the missing California courts identified in issue #119. Additional PRs may follow to add:
- 55 county Superior Courts
- Administrative tribunals (WCAB, CUIAB, PERB, etc.)