### PR TITLE
Fix 'Washignton' typo in courts.json locations

### DIFF
--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -67310,7 +67310,7 @@
         ],
         "id": "jpml",
         "level": "ljc",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "name": " United States Judicial Panel on Multidistrict Litigation",
         "notes": "See: https://en.wikipedia.org/wiki/Judicial_Panel_on_Multidistrict_Litigation",
         "regex": [
@@ -67335,7 +67335,7 @@
         "examples": [],
         "id": "ccpa",
         "level": "",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "name": "Court of Customs and Patent Appeals",
         "regex": [
             "U\\. S\\. Court of Customs Appeals",
@@ -67364,7 +67364,7 @@
         "id": "fcc",
         "jurisdiction": "D.C.",
         "level": "",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "locations": 1,
         "lower_courts": [],
         "name": "Decisions of the Federal Communications Commission",
@@ -67390,7 +67390,7 @@
         ],
         "id": "reglrailreorgct",
         "level": "trial",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "name": "Special Court Regional Rail Reorganization Act of 1973",
         "notes": "See: ",
         "regex": [
@@ -67418,7 +67418,7 @@
         ],
         "id": "usarmybrdrev",
         "level": "iac",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "name": "U.S. Army Board of Review",
         "name_abbreviation": "A. Bd. Rev.",
         "regex": [
@@ -67440,7 +67440,7 @@
         "examples": [],
         "id": "com",
         "level": "",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "name": "U.S. Commerce Court",
         "name_abbreviation": "U.S. Commerce Ct.",
         "regex": [
@@ -67465,7 +67465,7 @@
         ],
         "id": "cc",
         "level": "",
-        "location": "Washignton D.C.",
+        "location": "Washington D.C.",
         "name": "United States Court of Claims",
         "name_abbreviation": "Ct. of Claims",
         "regex": [


### PR DESCRIPTION
All 7 occurrences of "Washignton D.C." in courts.json are now "Washington D.C.", matching the spelling used in the rest of the file.

Affected courts: jpml, ccpa, fcc, reglrailreorgct, usarmybrdrev, and two others.

Fixes #127