### PR TITLE
Fix citation_string for six federal district courts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Upcoming Changes
 
+- Fix `citation_string` for six federal district courts (nyed, mdd, mnd, pamd, wvsd, nmid) #136
 -
 
 

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -17481,7 +17481,7 @@
     },
     {
         "case_types": [],
-        "citation_string": "D. Maryland",
+        "citation_string": "D. Md.",
         "court_url": "https://www.mdd.uscourts.gov/",
         "dates": [
             {
@@ -20124,7 +20124,7 @@
     },
     {
         "case_types": [],
-        "citation_string": "D. Minnesota",
+        "citation_string": "D. Minn.",
         "court_url": "http://www.mnd.uscourts.gov/",
         "dates": [
             {
@@ -24705,7 +24705,7 @@
     },
     {
         "case_types": [],
-        "citation_string": "E.D.N.Y",
+        "citation_string": "E.D.N.Y.",
         "court_url": "http://www.nyed.uscourts.gov/",
         "dates": [
             {
@@ -39414,7 +39414,7 @@
     {
         "active": true,
         "case_types": [],
-        "citation_string": "N. Mar. I.",
+        "citation_string": "D. N. Mar. I.",
         "court_url": "http://www.nmid.uscourts.gov/",
         "dates": [
             {
@@ -54584,7 +54584,7 @@
     },
     {
         "case_types": [],
-        "citation_string": "M.D. Penn.",
+        "citation_string": "M.D. Pa.",
         "court_url": "http://www.pamd.uscourts.gov/",
         "dates": [
             {
@@ -69092,7 +69092,7 @@
     },
     {
         "case_types": [],
-        "citation_string": "S.D.W. Va",
+        "citation_string": "S.D.W. Va.",
         "court_url": "http://www.wvsd.uscourts.gov/",
         "dates": [
             {


### PR DESCRIPTION
Part of #136 (group 1 of the fixes discussed there).

Corrects six `citation_string` values to the standard reporter abbreviations:

| id | before | after |
|---|---|---|
| `nyed` | `E.D.N.Y` | `E.D.N.Y.` |
| `mdd` | `D. Maryland` | `D. Md.` |
| `mnd` | `D. Minnesota` | `D. Minn.` |
| `pamd` | `M.D. Penn.` | `M.D. Pa.` |
| `wvsd` | `S.D.W. Va` | `S.D.W. Va.` |
| `nmid` | `N. Mar. I.` | `D. N. Mar. I.` |

Notes:
- `nmid`: the old value is the abbreviation for the NMI Commonwealth *Supreme Court* (see e.g. [Camacho v. NMI Settlement Fund (9th Cir. Nov. 20, 2025)](https://cdn.ca9.uscourts.gov/datastore/opinions/2025/11/20/23-16074.pdf), citing the NMI Supreme Court as "(N. Mar. I. Dec. 12, 2024)"); the district form in actual judicial usage is `D. N. Mar. I.` — e.g. [Fargo v. CNMI Dep't of Labor, No. 24-1504 (D.D.C. Sept. 12, 2025)](https://ecf.dcd.uscourts.gov/cgi-bin/show_public_doc?2024cv1504-18) twice cites D. N. Mar. I. decisions as "(D. N. Mar. I. Jan. 10, 2019)" and "(D. N. Mar. I. Jan. 24, 2019)".
- `wvsd`: only the undisputed missing final period is fixed, keeping the closed-up spacing consistent with sibling `wvnd` (`N.D.W. Va.`). Usage splits on the space — the Fourth Circuit itself writes "S.D. W. Va." (e.g. [Chaty v. Cebridge Acquisition (4th Cir. Mar. 27, 2025)](https://www.govinfo.gov/content/pkg/USCOURTS-ca4-23-01145/pdf/USCOURTS-ca4-23-01145-0.pdf), pp. 6–7, "(S.D. W. Va. Jan. 25, 2023)") — so the spacing convention is deliberately left alone.
- A dataset-wide sweep found no other malformed district citation strings (unabbreviated words like "Iowa", "Ohio", "Utah", "Guam" correctly take no period).

Tests: `python -m unittest tests` — 12/12 pass; JSON remains in canonical `sort_keys` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
