### PR TITLE
Fix date errors (njd, ncd, wvad) and empty-string dates that crash find_court (scd, mdch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Upcoming Changes
 
+- Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136
 -
 
 

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -17464,7 +17464,7 @@
         "dates": [
             {
                 "end": "1854-06-04",
-                "start": ""
+                "start": null
             }
         ],
         "examples": [],
@@ -21973,6 +21973,11 @@
             {
                 "end": "1801-02-13",
                 "start": "1789-09-24"
+            },
+            {
+                "end": null,
+                "notes": "Single district restored effective July 1, 1802 (2 Stat. 132)",
+                "start": "1802-07-01"
             }
         ],
         "examples": [],
@@ -39256,9 +39261,9 @@
                 "start": "1797-03-03"
             },
             {
-                "end": null,
-                "notes": "Divided in three into two",
-                "start": "1872-06-04"
+                "end": "1872-06-04",
+                "notes": "Divided into Eastern and Western districts, June 4, 1872 (17 Stat. 215)",
+                "start": null
             }
         ],
         "examples": [
@@ -62251,7 +62256,7 @@
                 "start": "1898-01-01"
             },
             {
-                "end": "",
+                "end": null,
                 "notes": "recombined",
                 "start": "1965-10-07"
             }
@@ -69122,7 +69127,8 @@
         "citation_string": "D. W.Va.",
         "dates": [
             {
-                "end": null,
+                "end": "1901-01-22",
+                "notes": "Divided into Northern and Southern districts (31 Stat. 736)",
                 "start": "1864-06-11"
             }
         ],

--- a/tests.py
+++ b/tests.py
@@ -195,6 +195,28 @@ class JsonTest(CourtsDBTestCase):
         ]
         self.assertEqual(len(cites), 0, msg=cites)
 
+    def test_dates_are_null_or_valid(self):
+        """Are all court dates either null or valid YYYY-MM-DD strings?
+
+        filter_courts_by_date only substitutes defaults for None, so any
+        other non-parseable value (e.g. an empty string) makes find_court
+        raise ValueError when called with date_found.
+        """
+        from datetime import datetime
+
+        bad = []
+        for row in load_courts_db():
+            for date_object in row.get("dates", []):
+                for key in ("start", "end"):
+                    value = date_object.get(key)
+                    if value is None:
+                        continue
+                    try:
+                        datetime.strptime(value, "%Y-%m-%d")
+                    except (TypeError, ValueError):
+                        bad.append((row["id"], key, value))
+        self.assertEqual(len(bad), 0, msg=bad)
+
     def test_id_length(self):
         """Make sure Id length does not exceed 15 characters"""
         max_id_length = max([len(row["id"]) for row in load_courts_db()])


### PR DESCRIPTION
Part of #136 (group 2). All dates verified against FJC legislative histories, and each change was cross-checked against CourtListener's cluster data for conflicts (details below).

- **`njd`** — adds an open range starting `1802-07-01`: the repeal of the Judiciary Act of 1801 restored New Jersey as a single district effective July 1, 1802, continuous since ([FJC](https://www.fjc.gov/history/courts/us-district-courts-districts-new-jersey-legislative-history)). The record previously ended in 1801, so date-filtered lookups treated the district as defunct. CL has zero clusters in the 1801–02 gap window, so nothing conflicts.
- **`ncd`** — the third range was inverted (`start: 1872-06-04, end: null`): June 4, 1872 (17 Stat. 215) is when the single district *ceased*, divided into Eastern and Western ([FJC](https://www.fjc.gov/history/courts/us-district-courts-districts-north-carolina-legislative-history)). Now `start: null, end: 1872-06-04`. `start` is left null deliberately: per FJC, North Carolina's organization between 1802 and 1872 (Albemarle/Cape Fear/Pamptico districts) doesn't map cleanly onto a single-district start date.
- **`wvad`** — sole range was open-ended; closed at `1901-01-22` (31 Stat. 736), when the district was divided into Northern and Southern ([FJC](https://www.fjc.gov/history/courts/us-district-courts-districts-west-virginia-legislative-history)).
- **`scd` / `mdch`** — the only two empty-string dates in the dataset (`scd` `end: ""`, `mdch` `start: ""`). These are worse than cosmetic: `filter_courts_by_date` only substitutes defaults for `None`, so the empty string reaches `strptime` and **`find_court(..., date_found=...)` raises `ValueError`** for any match set including these courts (reproducible on main: `find_court("District of South Carolina", date_found=datetime(2020,1,1))`). Both are now `null`, and a new regression test (`test_dates_are_null_or_valid`) validates every date in the dataset.

**Heads-up on downstream CL data (same class as the `okd` opinions in #136):** CL has 21 clusters attached to these courts with `date_filed` *after* the court's statutory end — misassigned on their face, since the court no longer existed. Reproducible via `/api/rest/v4/clusters/?docket__court=ncd&date_filed__gte=1872-06-05` (12 results) and `?docket__court=wvad&date_filed__gte=1901-01-23` (9 results); full lists below. These date fixes correctly stop courts-db from validating those assignments.

<details>
<summary>All 12 post-1872 clusters on <code>ncd</code></summary>

| cluster | date | judge | citation |
|---|---|---|---|
| [Holleman v. Dewey](https://www.courtlistener.com/opinion/8652653/holleman-v-dewey/) | 1872-07-01 | Brooks | 12 F. Cas. 341 |
| [Johnson v. The Frank S. Hall](https://www.courtlistener.com/opinion/8852216/johnson-v-the-frank-s-hall/) | 1889-03-15 | Seymour | 38 F. 258 |
| [Pearce v. The Thomas Newton](https://www.courtlistener.com/opinion/8853953/pearce-v-the-thomas-newton/) | 1889-11-20 | Seymour | 41 F. 106 |
| [United States v. Peralta](https://www.courtlistener.com/opinion/8758162/united-states-v-peralta/) | 1900-05-28 | Hawley | 102 F. 1006 |
| [Seaboard Air Line Ry. v. North Carolina R.](https://www.courtlistener.com/opinion/8767850/seaboard-air-line-ry-v-north-carolina-r/) | 1903-07-02 | Purnell | 123 F. 629 |
| [In re F. M. & S. Q. Carlile](https://www.courtlistener.com/opinion/8800668/in-re-f-m-s-q-carlile/) | 1912-09-30 | Connor | 199 F. 612 |
| [Brennan v. Tar Heel Home Supply](https://www.courtlistener.com/opinion/8802725/brennan-v-tar-heel-home-supply-inc/) | 1974-02-08 | Larkins | 62 F.R.D. 190 |
| [Day v. Heckler](https://www.courtlistener.com/opinion/8895462/day-v-heckler/) | 1983-11-01 | Potter | 575 F. Supp. 910 |
| [Genentech, Inc. v. Insmed Inc.](https://www.courtlistener.com/opinion/8760234/genentech-inc-v-insmed-inc/) | 2006-03-09 | Chen | 234 F.R.D. 667 |
| [Angell v. Kelly](https://www.courtlistener.com/opinion/8760221/angell-v-kelly/) | 2006-03-10 | Eliason | 234 F.R.D. 135 |
| [Gonzales v. Google, Inc.](https://www.courtlistener.com/opinion/8760235/gonzales-v-google-inc/) | 2006-03-17 | Ware | 234 F.R.D. 674 |
| [Manley v. Doe](https://www.courtlistener.com/opinion/8713870/manley-v-doe/) | 2012-02-02 | Dever | 849 F. Supp. 2d 594 |

Each opinion's own text shows its true venue — the strays aren't even all North Carolina (e.g. *Gonzales v. Google* and *Genentech* are N.D. Cal. discovery orders).

</details>

<details>
<summary>All 9 post-1901 clusters on <code>wvad</code></summary>

| cluster | date | judge | citation |
|---|---|---|---|
| [Byers Theaters, Inc. v. Murphy](https://www.courtlistener.com/opinion/8343577/byers-theaters-inc-v-murphy/) | 1940-05-20 | Barksdale | 1 F.R.D. 286 |
| [Vecellio v. United States](https://www.courtlistener.com/opinion/8750531/vecellio-v-united-states/) | 1961-07-15 | Field | 196 F. Supp. 1 |
| [United States v. Marietta Manufacturing Co.](https://www.courtlistener.com/opinion/8775129/united-states-v-marietta-manufacturing-co/) | 1967-05-18 | Christie | 268 F. Supp. 176 |
| [Jones v. Peyton](https://www.courtlistener.com/opinion/8782839/jones-v-peyton/) | 1968-06-03 | Dalton | 288 F. Supp. 129 |
| [Lawhorn v. Weinberger](https://www.courtlistener.com/opinion/8824172/lawhorn-v-weinberger/) | 1973-10-26 | Dalton | 365 F. Supp. 491 |
| [Herring v. Superintendent, Danville City Jail](https://www.courtlistener.com/opinion/8836375/herring-v-superintendent-danville-city-jail/) | 1974-11-19 | Dalton | 387 F. Supp. 410 |
| [Virginia Society for Human Life v. Caldwell](https://www.courtlistener.com/opinion/8343728/virginia-society-for-human-life-inc-v-caldwell/) | 1998-09-24 | Wilson | 26 F. Supp. 2d 868 |
| [Velma v. Federal National Mortgage Ass'n](https://www.courtlistener.com/opinion/8722795/velma-v-federal-national-mortgage-assn/) | 2013-02-12 | Moon | 923 F. Supp. 2d 828 |
| [United States v. Conrad](https://www.courtlistener.com/opinion/8722796/united-states-v-conrad/) | 2013-02-13 | Jones | 923 F. Supp. 2d 843 |

Per each opinion's own text, these split two ways: the Dalton/Moon/Wilson/Barksdale cases are **W.D. Va.** (Virginia — Danville, Roanoke, Lynchburg), while the Field/Christie cases are **S.D. W. Va.** — i.e., the CAP "D. W. Va." bucket absorbed both misparsed "W.D. Va." captions and post-split West Virginia cases.

</details>

Tests: 13/13 pass (12 existing + new regression test); JSON remains in canonical format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
