### PR TITLE
Fix type for 48 federal district courts mislabeled "appellate"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Upcoming Changes
 
+- Fix `type` for 48 federal district courts mislabeled "appellate" #136
 -
 
 

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -10647,7 +10647,7 @@
             "${usdc} Territory of Guam"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -11369,7 +11369,7 @@
             "District Court of The United States For The ${sd} Ill(i?nois)"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "citation_string": "",
@@ -11499,7 +11499,7 @@
             "${usdc} ${cd} Illinois"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -11522,7 +11522,7 @@
             "United States District Court for the District of Illinois"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -11547,7 +11547,7 @@
             "United States District Court for the Eastern District of Illinois"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -11708,7 +11708,7 @@
             "United States District Court For The District of Northern Indiana South Bend Division"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -11912,7 +11912,7 @@
             "United States District Court for the District of Indiana"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "active": false,
@@ -12021,7 +12021,7 @@
             "United States District Court N D Iowa Cedar Rapids Division"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -12046,7 +12046,7 @@
             "U S District Court Iowa Appanoose County"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -12262,7 +12262,7 @@
             "United States District Court for Eastern the District of Kansas"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -12482,7 +12482,7 @@
             "United States District Court W D Kentucky Louisville Division"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -16862,7 +16862,7 @@
             "^${d} ?(D)? ?Orleans"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -17192,7 +17192,7 @@
             "United States District Court Southern District of Maine"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "active": true,
@@ -17504,7 +17504,7 @@
             "${usdc} ${d} Md"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -18356,7 +18356,7 @@
             "United States District Court For The Eastern Division ?(of)? Michigan ?(Southern Division)?"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -18383,7 +18383,7 @@
             "United States District Court For The Western Division of Michigan"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -18424,7 +18424,7 @@
             "${usdc} ${d} ${mi}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "active": true,
@@ -20148,7 +20148,7 @@
             "United States District Court for the Northern District of Minnesota"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -20449,7 +20449,7 @@
             "District Court, E. D. Mississippi, N. D."
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -20522,7 +20522,7 @@
             "United States District Court for the District of Mississippi"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -20724,7 +20724,7 @@
             "United States District Court for the Southern District of Missouri"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "citation_string": "",
@@ -20799,7 +20799,7 @@
             "${usdc} ${d} ${mo}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -21595,7 +21595,7 @@
             "District Court Nevada"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "active": true,
@@ -21988,7 +21988,7 @@
             "United States District Court, D. New Jersey, Camden Vicinage"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -24478,7 +24478,7 @@
             "${usdc} ${nm}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -24782,7 +24782,7 @@
             "Northern District of New York"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -24850,7 +24850,7 @@
             "United States District Court For The Western Division of New York"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "citation_string": "",
@@ -38969,7 +38969,7 @@
             "${usdc} ${wd} North Carolina"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -39319,7 +39319,7 @@
             "${usdc} ${d} North Dakota"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -42196,7 +42196,7 @@
             "United States District Court For The District of Ohio"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -52929,7 +52929,7 @@
             "${usdc} ${nd} ${ok}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -52956,7 +52956,7 @@
             "United States District Court For The Western Division Oklahoma"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "appeal_to": null,
@@ -54288,7 +54288,7 @@
             "${usdc} District To Oregon"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "active": true,
@@ -54580,7 +54580,7 @@
             "${usdc} For The District For The ${ed} of ${pa}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -54612,7 +54612,7 @@
             "M\\.D\\. of Pennsylvania"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -56728,7 +56728,7 @@
             "${usdc} ${pa}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -62279,7 +62279,7 @@
             "${sc} District Court"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -62301,7 +62301,7 @@
             "United States District Court for the Eastern District of South Carolina"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -63220,7 +63220,7 @@
             "United States District Court For The Western Division of Texas Waco Division"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -63338,7 +63338,7 @@
             "${usdc} ${d} ${tx}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -63612,7 +63612,7 @@
             "District Court United States"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "citation_string": "",
@@ -63932,7 +63932,7 @@
             "${usdc} ${vt} ${d}"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -64269,7 +64269,7 @@
             "District Court For The Eastern Division of Virginia Alexandria Division"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -67613,7 +67613,7 @@
             "${usdc} ${wd} Wash(ington)"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "active": true,
@@ -68170,7 +68170,7 @@
             "United States District Court for the District of D.C."
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -69115,7 +69115,7 @@
             "United States District Court S D W Va Huntington Division"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -69140,7 +69140,7 @@
             "United States District Court for the District of West Virginia"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],
@@ -69372,7 +69372,7 @@
             "United States District Court For The Eastern Division of Wisconsin"
         ],
         "system": "federal",
-        "type": "appellate"
+        "type": "trial"
     },
     {
         "case_types": [],


### PR DESCRIPTION
Part of #136 (group 3). Changes `type` from `"appellate"` to `"trial"` for every federal district court record so labeled — district courts are the federal system's general-jurisdiction trial courts.

The issue reported 35 active districts; a full sweep of the dataset found 48 records total:

- the 35 from the issue (`dcd, gud, iand, iasd, ilcd, ilsd, innd, ksd, kywd, mdd, med, mied, miwd, mnd, mowd, msnd, ncwd, ndd, njd, nmd, nvd, nynd, nywd, oknd, okwd, ord, paed, pamd, scd, txwd, vaed, vtd, wawd, wied, wvsd`)
- the `usdistct` parent record ("United States District Court") itself
- `wvad` (defunct single D. W. Va.)
- 11 defunct historical districts: `illinoisd, illinoised, indianad, michd, missd, mod, ohiod, orld, pennsylvaniad, southcarolinaed, texd` — each verified as a district (trial) court against its FJC legislative history page: [Illinois](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-illinois-legislative-history) (`illinoisd`, `illinoised`), [Indiana](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-indiana-legislative-history), [Michigan](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-michigan-legislative-history), [Mississippi](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-mississippi-legislative-history), [Missouri](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-missouri-legislative-history), [Ohio](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-ohio-legislative-history), [Louisiana](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-louisiana-legislative-history) (`orld`, the Territory of Orleans court), [Pennsylvania](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-pennsylvania-legislative-history), [South Carolina](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-south-carolina-legislative-history), [Texas](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-texas-legislative-history).

Derivation (returns exactly these 48):

```python
[c["id"] for c in courts
 if c.get("system") == "federal"
 and "District Court" in c.get("name", "")
 and "Bankruptcy" not in c["name"]
 and c.get("type") == "appellate"]
```

Nothing in the library or test suite branches on `type` except the bankruptcy filter, which is unaffected.

Tests: 12/12 pass; JSON remains in canonical format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
