### PR TITLE
Remove phantom "District of Oklahoma" court (okd)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Upcoming Changes
 
+- Remove phantom "District of Oklahoma" court (okd) #136
 -
 
 

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -53334,32 +53334,6 @@
         "type": "bankruptcy"
     },
     {
-        "appeal_to": "ca10",
-        "citation_string": "",
-        "dates": [
-            {
-                "end": null,
-                "notes": "Divided in two",
-                "start": null
-            }
-        ],
-        "examples": [
-            "District Court D Oklahoma"
-        ],
-        "federal_circuit": 10,
-        "id": "okd",
-        "jurisdiction": "",
-        "level": "gjc",
-        "location": "Oklahoma",
-        "name": "United States District Court for the District of Oklahoma",
-        "regex": [
-            "^${d} ?(D)? ?${ok}",
-            "${usdc} ${d} ${ok}"
-        ],
-        "system": "federal",
-        "type": "trial"
-    },
-    {
         "active": false,
         "case_types": [],
         "citation_string": "",


### PR DESCRIPTION
Part of #136 (group 4). Opening as a draft since per the discussion there, the two CourtListener clusters mapped to `okd` need to be reassigned first, and that's @flooie's call.

No single District of Oklahoma ever existed — Oklahoma was organized as Eastern and Western districts from statehood (34 Stat. 267, effective November 16, 1907), with the Northern District added in 1925 ([FJC](https://www.fjc.gov/history/courts/u.s.-district-courts-districts-oklahoma-judicial-district-organization-1907-present)). The record has `dates: [{start: null, end: null}]` and an empty `citation_string`, and nothing else in the dataset references it (no children, no cross-refs).

Both CL clusters belong to `oked`:

- [*Whitchurch v. Burge*, 17 F. Supp. 234 (1936)](https://www.courtlistener.com/opinion/8660749/whitchurch-v-burge/) (cluster 8660749): the opinion opens "WILLIAMS, District Judge" — [Robert Lee Williams](https://www.fjc.gov/history/judges/williams-robert-lee), whose only district seat was E.D. Okla. (1919–1937) — and describes removal from Pontotoc County state court, in the Eastern District. The Tenth Circuit affirmance ([*Whitchurch v. Crawford*, 92 F.2d 249](https://www.courtlistener.com/opinion/1501900/whitchurch-v-crawford/)) is captioned in the West print "Appeal from the District Court of the United States for the Eastern District of Oklahoma; Robert L. Williams, Judge."
- [*In re Everybody's Grocery & Meat Market*, 173 F. 492 (1908)](https://www.courtlistener.com/opinion/8788733/in-re-everybodys-grocery-meat-market/) (cluster 8788733): authored by "CAMPBELL, District Judge." In 1908 Oklahoma had two district judges — [Ralph E. Campbell](https://en.wikipedia.org/wiki/Ralph_E._Campbell) (E.D.) and [John Hazelton Cotteral](https://www.fjc.gov/history/judges/cotteral-john-hazelton) (W.D.) — so the attribution settles it.

The error is upstream in CAP's court metadata (id 9622) on both cases: the [archive.org record](https://dn711200.ca.archive.org/0/items/law.free.cap.f.173/492.29138.json) grossir linked, and the Whitchurch entry (case id 4179855) in [static.case.law/f-supp/17/CasesMetadata.json](https://static.case.law/f-supp/17/CasesMetadata.json).

One behavior change to be aware of: strings like "District Court D Oklahoma" currently resolve to `okd` and after this would return no match. If you'd rather keep the record with closed dates, or point its regexes somewhere, glad to rework it.

Tests: 12/12 pass; JSON stays in canonical format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)