### PR TITLE
Fix dead or wrong court_url for okwd, alsd, and nmd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Upcoming Changes
 
+- Fix dead or wrong `court_url` for three district courts: okwd (pointed at the generic uscourts.gov homepage), alsd (www.als.uscourts.gov no longer resolves), nmd (pointed at the retired nmcourt.fed.us host)
 - Fix `type` for 48 federal district courts mislabeled "appellate" #136
 - Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136
 - Fix `citation_string` for six federal district courts (nyed, mdd, mnd, pamd, wvsd, nmid) #136

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -561,7 +561,7 @@
     {
         "appeal_to": "ca11",
         "citation_string": "S.D. Ala.",
-        "court_url": "http://www.als.uscourts.gov/",
+        "court_url": "https://www.alsd.uscourts.gov/",
         "dates": [
             {
                 "end": null,
@@ -24463,7 +24463,7 @@
     {
         "case_types": [],
         "citation_string": "D.N.M.",
-        "court_url": "http://www.nmcourt.fed.us/web/DCDOCS/dcindex.html",
+        "court_url": "https://www.nmd.uscourts.gov/",
         "dates": [
             {
                 "end": null,
@@ -52939,7 +52939,7 @@
     {
         "case_types": [],
         "citation_string": "W.D. Okla.",
-        "court_url": "http://www.uscourts.gov/",
+        "court_url": "https://www.okwd.uscourts.gov/",
         "dates": [
             {
                 "end": null,


### PR DESCRIPTION
Three `court_url` values point at pages that no longer serve the court:

| id | current value | problem | fixed value |
|---|---|---|---|
| okwd | `http://www.uscourts.gov/` | generic national homepage | `https://www.okwd.uscourts.gov/` |
| alsd | `http://www.als.uscourts.gov/` | host no longer resolves | `https://www.alsd.uscourts.gov/` |
| nmd | `http://www.nmcourt.fed.us/web/DCDOCS/dcindex.html` | retired host, no longer resolves | `https://www.nmd.uscourts.gov/` |

Verification (re-checked 2026-07-08):
- The two dead hosts are NXDOMAIN from both 8.8.8.8 and 1.1.1.1 (not a
  local-resolver artifact), and fail with `ERR_NAME_NOT_RESOLVED` in a
  browser. The replacement URLs return 200 and serve the correct court
  sites ("Welcome to Western District of Oklahoma", "Southern District of
  Alabama | United States District Court", "District of New Mexico |
  United States District Court").
- Wayback Machine confirms both dead URLs were formerly correct — captures
  of als.uscourts.gov (1998–2015) title "United States District Court /
  Southern District of Alabama", and nmcourt.fed.us (2003–2012) reads
  "Welcome to the United States District Court for the District of New
  Mexico" — so these are stale links, not wrong courts.
- The fixed values match uscourts.gov's own Court Website Links directory.

Deliberately left alone: four defunct districts (illinoisd, ohiod,
pennsylvaniad, tennessed) also carry the generic homepage URL, which may be
intentional for courts with no modern site; and a few districts use variant
subdomains (are/id/txs.uscourts.gov) that are live. Separately, ~200
court_url values are http:// on uscourts.gov hosts that all serve https —
happy to do that as a follow-up if wanted (mechanical, with a verification
log), but it seemed better to ask first.

No behavior change; data only. Tests pass.
