### PR TITLE
Fix typos in three federal circuit-court names (#141)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - Fix `type` for 48 federal district courts mislabeled "appellate" #136
 - Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136
 - Fix `citation_string` for six federal district courts (nyed, mdd, mnd, pamd, wvsd, nmid) #136
--
+- Fix typos in three federal circuit-court `name` fields (circtndil, circtsdil "Illnois"; circtddc doubled "District of") #141
 
 
 ## Current Version

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -11268,7 +11268,7 @@
         "id": "circtndil",
         "level": "iac",
         "location": "Illinois",
-        "name": "U.S. Circuit Court for the Northern District of Illnois",
+        "name": "U.S. Circuit Court for the Northern District of Illinois",
         "name_abbreviation": "N. Ill. Cir. Ct",
         "parent": "uscirct",
         "regex": [
@@ -11292,7 +11292,7 @@
         "id": "circtsdil",
         "level": "iac",
         "location": "Illinois",
-        "name": "U.S. Circuit Court for the Southern District of Illnois",
+        "name": "U.S. Circuit Court for the Southern District of Illinois",
         "name_abbreviation": "S. Ill. Cir. Ct",
         "parent": "uscirct",
         "regex": [
@@ -67997,7 +67997,7 @@
         "id": "circtddc",
         "level": "iac",
         "location": "Washington D.C.",
-        "name": "U.S. Circuit Court for the District of District of Columbia",
+        "name": "U.S. Circuit Court for the District of Columbia",
         "name_abbreviation": "Dist. of Columbia Cir. Ct",
         "parent": "uscirct",
         "regex": [

--- a/tests.py
+++ b/tests.py
@@ -217,6 +217,28 @@ class JsonTest(CourtsDBTestCase):
                         bad.append((row["id"], key, value))
         self.assertEqual(len(bad), 0, msg=bad)
 
+    def test_court_names_match_their_own_spelling(self):
+        """Each court's ``name`` doubles as a match string via gather_regexes,
+        so a typo in ``name`` silently prevents the court from matching its own
+        canonical name. Guards the three circuit-court typos fixed for #141
+        ("Illnois", doubled "District of").
+        """
+        expected = {
+            "circtndil": "U.S. Circuit Court for the Northern District of Illinois",
+            "circtsdil": "U.S. Circuit Court for the Southern District of Illinois",
+            "circtddc": "U.S. Circuit Court for the District of Columbia",
+        }
+        for court_id, name in expected.items():
+            stored = find_court_by_id(court_id)[0]["name"]
+            self.assertEqual(
+                stored, name, msg=f"{court_id} name is {stored!r}"
+            )
+            self.assertIn(
+                court_id,
+                find_court(name),
+                msg=f"{court_id} does not match its own name {name!r}",
+            )
+
     def test_id_length(self):
         """Make sure Id length does not exceed 15 characters"""
         max_id_length = max([len(row["id"]) for row in load_courts_db()])


### PR DESCRIPTION
Fixes #141.

Three federal circuit-court records had typos in their `name` field. Because `name` doubles as a match string via `gather_regexes`, a misspelled name silently failed to match its own correct spelling — `find_court()` returned `[]` for all three canonical names before this change.

| id | before | after |
|---|---|---|
| `circtndil` | `...Northern District of Illnois` | `...Northern District of Illinois` |
| `circtsdil` | `...Southern District of Illnois` | `...Southern District of Illinois` |
| `circtddc` | `...District of District of Columbia` | `...District of Columbia` |

The `regex` lists already used the correct spellings, so only `name` changed. A dataset-wide sweep of all 2,809 court names confirms no other doubled words or `Illnois` residue remain.

Added a regression test (`test_court_names_match_their_own_spelling`) asserting each fixed court resolves from its own canonical name; it fails on the current data and passes with the fix.

Tests: `python -m unittest tests` — 14/14 pass; JSON remains in canonical `sort_keys` format.