### PR TITLE
Fix six regexes with malformed template placeholders (#132)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ## Upcoming Changes
 
 - Fix `type` for 48 federal district courts mislabeled "appellate" #136
+- Fix six regexes with malformed template placeholders (kanctapp, lactapp, masssuperct, txsd, vib, waed); add a test that rejects unsubstituted `{var}`/`{$var}` templates #132
 - Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136
 - Fix `citation_string` for six federal district courts (nyed, mdd, mnd, pamd, wvsd, nmid) #136
 -

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -12280,7 +12280,7 @@
         "location": "Kansas",
         "name": "Court of Appeals of Kansas",
         "regex": [
-            "{coa} Kansas",
+            "${coa} Kansas",
             "Court of Appeals? of Kansas",
             "Court of Appeals of The State of Kansas",
             "Kansas Court of Appeals"
@@ -16905,7 +16905,7 @@
         "regex": [
             "Court of Appeals? of Louisiana",
             "Louisiana Circuit Courts of Appeal",
-            "(State of) ?Louisiana ${coa} {bw} Circuit",
+            "(State of) ?Louisiana ${coa} ${bw} Circuit",
             "Louisia?na Court of Appeal",
             "State of Louisiana Parish of Orleans Court of Appeal",
             "Court of Appeal Louisiana",
@@ -18039,7 +18039,7 @@
         "location": "Massachusetts",
         "name": "Massachusetts Superior Court",
         "regex": [
-            "Massachusetts {super}",
+            "Massachusetts ${super}",
             "State of Massachusetts Superior Court",
             "Superior Court of Massachusetts"
         ],
@@ -63192,7 +63192,7 @@
             "${usdc} ${sd} ${tx}",
             "${d} Southern Division Texas Houston Div",
             "${sd} Texas Houston Division ${usdc}",
-            "${d} {$usa}} ${sd} Texas Corpus Christi Division",
+            "${d} ${usa} ${sd} Texas Corpus Christi Division",
             "${usdc} ${sd} Tex Brownsville Division"
         ],
         "system": "federal",
@@ -64159,7 +64159,7 @@
         "location": "Virgin Islands",
         "name": "United States Bankruptcy Court, D. Virgin Islands",
         "regex": [
-            "${usdc} {d} Virgin Islands",
+            "${usdc} ${d} Virgin Islands",
             "${usbcd} (the)? ?Virgin Islands",
             "District Court of The Virgin Islands"
         ],
@@ -67577,7 +67577,7 @@
         "name": "District Court, E.D. Washington",
         "parent": "usdistct",
         "regex": [
-            "{usdc} ${ed} Wash(ington)?",
+            "${usdc} ${ed} Wash(ington)?",
             "District Court E D Washington",
             "U S District Court For The Eastern District of Washington Northern Division",
             "United States District Court For The Eastern District Washington",

--- a/tests.py
+++ b/tests.py
@@ -217,6 +217,38 @@ class JsonTest(CourtsDBTestCase):
                         bad.append((row["id"], key, value))
         self.assertEqual(len(bad), 0, msg=bad)
 
+    def test_regexes_render_and_compile(self):
+        """Every regex template must be written as ${var}.
+
+        A placeholder written as {var} is left untouched by
+        Template.substitute; a transposed {$var} has its inner $var expanded
+        but keeps the stray braces (e.g. txsd's `{$usa}}`). Either way the
+        result is a regex that still compiles but can never match its
+        intended text (#132) -- so a plain compile check misses both. We scan
+        the raw (pre-substitution) regexes for any {...} that is not a ${...}
+        reference or a {n,m} quantifier, and also confirm every regex compiles
+        after substitution.
+        """
+        brace = re.compile(r"(?<!\$)\{([^{}]*)\}")
+        bad = []
+        with open(
+            os.path.join(db_root, "data", "courts.json"), encoding="utf-8"
+        ) as f:
+            for row in json.load(f):
+                for regex in row.get("regex", []):
+                    for match in brace.finditer(regex):
+                        content = match.group(1)
+                        if re.fullmatch(r"[0-9]+(,[0-9]*)?", content):
+                            continue  # legitimate {n} / {n,m} quantifier
+                        bad.append((row["id"], regex, content))
+        for row in load_courts_db():
+            for regex in row.get("regex", []):
+                try:
+                    re.compile(regex)
+                except re.error as e:
+                    bad.append((row["id"], regex, str(e)))
+        self.assertEqual(len(bad), 0, msg=bad)
+
     def test_id_length(self):
         """Make sure Id length does not exceed 15 characters"""
         max_id_length = max([len(row["id"]) for row in load_courts_db()])


### PR DESCRIPTION
Toward #132.

Six regexes have malformed template placeholders that survive `Template.substitute` as literal braces, so the regex can never match its intended text:

| id | before | after |
|---|---|---|
| `kanctapp` | `{coa} Kansas` | `${coa} Kansas` |
| `lactapp` | `... ${coa} {bw} Circuit` | `... ${coa} ${bw} Circuit` |
| `masssuperct` | `Massachusetts {super}` | `Massachusetts ${super}` |
| `vib` | `${usdc} {d} Virgin Islands` | `${usdc} ${d} Virgin Islands` |
| `waed` | `{usdc} ${ed} Wash(ington)?` | `${usdc} ${ed} Wash(ington)?` |
| `txsd` | `${d} {$usa}} ${sd} Texas Corpus Christi Division` | `${d} ${usa} ${sd} Texas Corpus Christi Division` |

Five are placeholders missing the `$`; `txsd` is a transposed `{$usa}}`. In every case the affected regex still *compiles* (the stray braces are just literal), which is why a plain compile check doesn't catch them — they have to be caught at the template level.

**Test:** `test_regexes_render_and_compile` scans the raw (pre-substitution) regexes and rejects any `{...}` that isn't a `${...}` reference or a `{n,m}` quantifier, then confirms every regex compiles after substitution. It fails on current `main` (flags exactly these 6) and passes with the fix.

**Deliberately left in place** — the trailing-number regexes also mentioned in #132 (`Florida2016`, `Nebraska6`, `New Yorke0`): `find_court` requires a regex to span the entire input by default, so these are the only patterns that match those OCR'd caption variants. Removing them would silently stop those strings from resolving, so they're kept.

Tests: `python -m unittest tests` — 14/14 pass; JSON remains in canonical `sort_keys` format.