### PR TITLE
Fix Florida circuit court date ranges (#143)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Upcoming Changes
 
+- Fix the date ranges for the Northern and Southern District of Florida U.S. circuit courts #143
 - Fix `type` for 48 federal district courts mislabeled "appellate" #136
 - Fix six regexes with malformed template placeholders (kanctapp, lactapp, masssuperct, txsd, vib, waed); add a test that rejects unsubstituted `{var}`/`{$var}` templates #132
 - Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -7607,8 +7607,8 @@
         "citation_string": "C.C.N.D. Fla.",
         "dates": [
             {
-                "end": null,
-                "start": null
+                "end": "1911-12-31",
+                "start": "1862-07-15"
             }
         ],
         "examples": [
@@ -7637,7 +7637,7 @@
         "dates": [
             {
                 "end": "1911-12-31",
-                "start": "1862-01-01"
+                "start": "1862-07-15"
             }
         ],
         "examples": [],


### PR DESCRIPTION
Part of #143.

## What changed

- added the missing `1862-07-15` through `1911-12-31` range for `circtndfl`
- corrected `circtsdfl` from its approximate January start to the same statutory creation date
- noted the correction in `CHANGES.md`

The [Federal Judicial Center legislative history](https://www.fjc.gov/history/courts/u.s.-circuit-courts-districts-florida-legislative-history) says Congress established both courts on July 15, 1862. It also says the circuit courts were abolished effective January 1, 1912, so December 31, 1911 remains the final active date used by this dataset.

I left the Mississippi Territory and New York records in #143 unchanged because their correct treatment still needs separate research.

## Testing

- `python3 -m unittest tests`
- verified that `courts.json` remains in canonical sorted format
- verified both Florida records have the expected date range
- `git diff --check`
