### PR TITLE
fix: correct and test court references in `courts.json`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - Fix six regexes with malformed template placeholders (kanctapp, lactapp, masssuperct, txsd, vib, waed); add a test that rejects unsubstituted `{var}`/`{$var}` templates #132
 - Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136
 - Fix `citation_string` for six federal district courts (nyed, mdd, mnd, pamd, wvsd, nmid) #136
+- Fix `appeal_to` references of `delaldct`, `alajudct`, and `ca11`.
+- Test correctness of references in `appeal_to` and `parent` fields.
 -
 
 

--- a/courts_db/data/courts.json
+++ b/courts_db/data/courts.json
@@ -104,7 +104,7 @@
         "type": "appellate"
     },
     {
-        "appeal_to": "colr",
+        "appeal_to": "ala",
         "citation_string": "",
         "dates": [
             {
@@ -4069,7 +4069,7 @@
     },
     {
         "active": true,
-        "appeal_to": "Court of Common Pleas",
+        "appeal_to": "delctcompl",
         "citation_string": "",
         "dates": [
             {
@@ -10553,9 +10553,6 @@
         "type": "bankruptcy"
     },
     {
-        "appeal_to": [
-            "scotus"
-        ],
         "citation_string": "11th Cir.",
         "court_url": "http://www.ca11.uscourts.gov/",
         "dates": [

--- a/tests.py
+++ b/tests.py
@@ -45,6 +45,13 @@ class DataTest(CourtsDBTestCase):
             find_court_by_id(matches[0])[0].get("parent", None), None
         )
 
+        for court in self.courts:
+            reference = court.get("parent")
+            if reference is not None:
+                with self.subTest(court_id=court["id"]):
+                    matches = find_court_by_id(reference)
+                    self.assertGreater(len(matches), 0, "No court found")
+
     def test_all_example(self):
         """Can we extract the correct court id from string and date?"""
 

--- a/tests.py
+++ b/tests.py
@@ -52,6 +52,16 @@ class DataTest(CourtsDBTestCase):
                     matches = find_court_by_id(reference)
                     self.assertGreater(len(matches), 0, "No court found")
 
+    def test_appeal_to_courts(self):
+        """Can we find the appeal_to court"""
+
+        for court in self.courts:
+            reference = court.get("appeal_to")
+            if reference is not None:
+                with self.subTest(court_id=court["id"]):
+                    matches = find_court_by_id(reference)
+                    self.assertGreater(len(matches), 0, "No court found")
+
     def test_all_example(self):
         """Can we extract the correct court id from string and date?"""
 

--- a/tests.py
+++ b/tests.py
@@ -49,15 +49,16 @@ class DataTest(CourtsDBTestCase):
         """Can we extract the correct court id from string and date?"""
 
         for court in self.courts:
-            for court_str_example in court["examples"]:
-                print(f"Testing {court_str_example}", end=" ... ")
-                matches = find_court(court_str=court_str_example)
-                self.assertIn(
-                    court["id"],
-                    matches,
-                    f"Failure to find {court['id']} in {court_str_example}",
-                )
-                print("√")
+            with self.subTest(court_id=court["id"]):
+                for court_str_example in court["examples"]:
+                    print(f"Testing {court_str_example}", end=" ... ")
+                    matches = find_court(court_str=court_str_example)
+                    self.assertIn(
+                        court["id"],
+                        matches,
+                        f"Failure to find {court['id']} in {court_str_example}",
+                    )
+                    print("√")
 
     def test_location_filter(self):
         """Can we use location to filter properly"""


### PR DESCRIPTION
## Fixes
This changes `appeal_to` values of `delaldct`, `alajudct`, and `ca11` so that values resolve. Tests are added to ensure that `appeal_to` and `parent` continue to resolve.

## Summary
The values of `parent` and `appeal_to` are evidently intended to be the `id` value of another entry in the `courts.json` structure. Without testing, these values can easily become incorrect. This change introduces tests for their integrity. It also address the 3 instances where the value is not the expected string. The values used for `delaldct` and `alajudct` are changed to the `id` of the Delaware Court of Common Pleas and Alabama Supreme Court, respectively. The field for `ca11`  is dropped entirely, because it uses an unexpected data structure and no sibling courts follow its example.

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
