### PR TITLE
chore: add annotations for all functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fix six regexes with malformed template placeholders (kanctapp, lactapp, masssuperct, txsd, vib, waed); add a test that rejects unsubstituted `{var}`/`{$var}` templates #132
 - Fix date errors for njd, ncd, and wvad; replace empty-string dates (scd, mdch) that made `find_court` raise `ValueError` when called with `date_found` #136
 - Fix `citation_string` for six federal district courts (nyed, mdd, mnd, pamd, wvsd, nmid) #136
+- Give rudimentary type hints to all functions.
 -
 
 

--- a/courts_db/__init__.py
+++ b/courts_db/__init__.py
@@ -112,7 +112,10 @@ def find_court_ids_by_name(
     return list(court_matches)
 
 
-def reduce_court_list(court_list):
+_CourtMatch = tuple[str, str, Optional[str]]
+
+
+def reduce_court_list(court_list: list[_CourtMatch]) -> list[_CourtMatch]:
     """Reduce to lowest possible match
 
     :param court_list: List of matches
@@ -127,7 +130,11 @@ def reduce_court_list(court_list):
     return reduced_list
 
 
-def filter_courts_by_date(matches, date_found, strict_dates=False):
+def filter_courts_by_date(
+    matches: list[str],
+    date_found: datetime,
+    strict_dates: Optional[bool] = False,
+) -> list[str]:
     """Filter IDs by date found.
 
     Strict dates should be more useful as dates are filled in.
@@ -169,7 +176,9 @@ def filter_courts_by_date(matches, date_found, strict_dates=False):
     return filtered_results
 
 
-def filter_courts_by_bankruptcy(matches, bankruptcy):
+def filter_courts_by_bankruptcy(
+    matches: list[str], bankruptcy: Optional[bool]
+) -> list[str]:
     from . import courts
 
     results = [court for court in courts if court["id"] in matches]
@@ -180,7 +189,7 @@ def filter_courts_by_bankruptcy(matches, bankruptcy):
     return [court["id"] for court in results if court["type"] != "bankruptcy"]
 
 
-def find_court_by_id(court_id):
+def find_court_by_id(court_id: str) -> list[dict]:
     """Find court dictionary using court id code.
 
     :param court_id: Court code used by Courtlistener.com

--- a/courts_db/utils.py
+++ b/courts_db/utils.py
@@ -116,14 +116,14 @@ ordinals = [
 #     return cd
 
 
-def make_court_dictionary(courts):
+def make_court_dictionary(courts: list[dict]) -> dict[str, dict]:
     cd = {}
     for court in courts:
         cd[court["id"]] = court
     return cd
 
 
-def load_courts_db():
+def load_courts_db() -> list[dict]:
     """Load the court data from disk, and render regex variables
 
     Court data is on disk as one main JSON file, another containing variables,
@@ -179,7 +179,7 @@ def load_courts_db():
     return data
 
 
-def gather_regexes(courts):
+def gather_regexes(courts: list[dict]) -> list[tuple]:
     """Create a variable mapping regexes to court IDs
 
     :param courts: The court DB


### PR DESCRIPTION
## Fixes
This adds annotations missing from the public interface. It clarifies that `find_court_by_id()` returns an array.

## Summary
Dependencies with absent type annotations are a hinderance to package consumers. Whereever possible, a package should provide annotations for their public interface. The annotations provide more potent guidance than documentation and also prevent errors, for example, thinking that, because `find_court_by_id()` uses the singular, that it would return a `dict | None` not a `list[dict]`.

This change adds rudimentary types for all functions in the project. There is no validation, but this change is pulled eagerly from a more thoroughgoing change using Pyrefly to statically check the project. Here the types were checked - and passed. It addressed the following errors:

```
ERROR courts_db/__init__.py:23:17-21: `__getattr__` is missing an annotation for parameter `name` [implicit-any-parameter]
ERROR courts_db/__init__.py:115:23-33: `reduce_court_list` is missing an annotation for parameter `court_list` [implicit-any-parameter]
ERROR courts_db/__init__.py:130:27-34: `filter_courts_by_date` is missing an annotation for parameter `matches` [implicit-any-parameter]
ERROR courts_db/__init__.py:130:36-46: `filter_courts_by_date` is missing an annotation for parameter `date_found` [implicit-any-parameter]
ERROR courts_db/__init__.py:130:48-60: `filter_courts_by_date` is missing an annotation for parameter `strict_dates` [implicit-any-parameter]
ERROR courts_db/__init__.py:173:33-40: `filter_courts_by_bankruptcy` is missing an annotation for parameter `matches` [implicit-any-parameter]
ERROR courts_db/__init__.py:173:42-52: `filter_courts_by_bankruptcy` is missing an annotation for parameter `bankruptcy` [implicit-any-parameter]
ERROR courts_db/__init__.py:184:22-30: `find_court_by_id` is missing an annotation for parameter `court_id` [implicit-any-parameter]
```

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
